### PR TITLE
[MMCA-4102] Update version & configuration for CDS Financials service - July - V2

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,12 +4,12 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.15.0"
+  val bootstrapVersion = "7.19.0"
 
   val compile = Seq(
     ws,
     "uk.gov.hmrc" %% "bootstrap-backend-play-28" % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.2.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0"
   )
 
   val test = Seq(


### PR DESCRIPTION
Below libraries have been updated to the latest version

uk.gov.hmrc:bootstrap-backend-play-28
uk.gov.hmrc:bootstrap-test-play-28

uk.gov.hmrc.mongo:hmrc-mongo-play-28