### PR TITLE
[MMCA-4192] - CDSP-10637  Keep track of all positive and negative results for all searches (Backend changes)

### DIFF
--- a/app/controllers/StatementSearchFailureNotificationController.scala
+++ b/app/controllers/StatementSearchFailureNotificationController.scala
@@ -93,11 +93,14 @@ class StatementSearchFailureNotificationController @Inject()(
                                                               failureReasonCode: String): Future[Option[Unit]] =
     for {
       optHistDocReqSearchDoc <- cacheService.retrieveHistDocRequestSearchDocForStatementReqId(statementRequestID)
-      histDoc: Option[HistoricDocumentRequestSearch] <- updateSearchRequestIfInProcess(statementRequestID,
+      updatedHistDoc: Option[HistoricDocumentRequestSearch] <- updateSearchRequestIfInProcess(statementRequestID,
         failureReasonCode, optHistDocReqSearchDoc)
     } yield {
-      histDoc.map {
-        _ => ()
+      updatedHistDoc.map {
+        histDoc => {
+          if (!(histDoc.resultsFound == SearchResultStatus.yes)) cacheService.updateResultsFoundStatus(histDoc)
+          else ()
+        }
       }
     }
 

--- a/app/controllers/StatementSearchFailureNotificationController.scala
+++ b/app/controllers/StatementSearchFailureNotificationController.scala
@@ -59,7 +59,7 @@ class StatementSearchFailureNotificationController @Inject()(
 
   private def processStatementReqId(request: Request[JsValue]) = {
     Json.fromJson(request.body) match {
-      case JsSuccess(value, _) => {
+      case JsSuccess(value, _) =>
         val statementRequestID = value.StatementSearchFailureNotificationMetadata.statementRequestID
         val failureReasonCode = value.StatementSearchFailureNotificationMetadata.reason
 
@@ -67,7 +67,7 @@ class StatementSearchFailureNotificationController @Inject()(
           s" ::: $statementRequestID with reason :: $failureReasonCode")
 
         updateHistoricDocumentRequestSearchForStatReqId(statementRequestID, failureReasonCode)
-      }
+
       case JsError(_) => logger.error("Request is not properly formed and failing in parsing")
     }
   }
@@ -98,7 +98,8 @@ class StatementSearchFailureNotificationController @Inject()(
     } yield {
       updatedHistDoc.map {
         histDoc => {
-          if (!(histDoc.resultsFound == SearchResultStatus.yes)) cacheService.updateResultsFoundStatus(histDoc)
+          if (!(histDoc.resultsFound == SearchResultStatus.yes))
+            cacheService.updateResultsFoundStatusToNoIfEligible(histDoc)
           else ()
         }
       }

--- a/app/models/HistoricDocumentRequestSearch.scala
+++ b/app/models/HistoricDocumentRequestSearch.scala
@@ -17,7 +17,9 @@
 package models
 
 import models.requests.HistoricDocumentRequest
-import play.api.libs.json.{Json, OFormat}
+import org.joda.time.DateTime
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJodaFormats
 import utils.Utils.{emptyString, zeroPad}
 
 import java.util.UUID
@@ -27,11 +29,13 @@ case class HistoricDocumentRequestSearch(searchID: UUID,
                                          searchStatusUpdateDate: String = emptyString,
                                          currentEori: String,
                                          params: Params,
-                                         searchRequests: Set[SearchRequest]) {
+                                         searchRequests: Set[SearchRequest],
+                                         expireAt:DateTime = DateTime.now()) {
   require(searchRequests.nonEmpty, "searchRequests is empty")
 }
 
 object HistoricDocumentRequestSearch {
+  implicit val dateFormats: Format[DateTime] = MongoJodaFormats.dateTimeFormat
   implicit val historicDocumentRequestSearchFormat: OFormat[HistoricDocumentRequestSearch] =
     Json.format[HistoricDocumentRequestSearch]
 

--- a/app/models/HistoricDocumentRequestSearch.scala
+++ b/app/models/HistoricDocumentRequestSearch.scala
@@ -30,7 +30,7 @@ case class HistoricDocumentRequestSearch(searchID: UUID,
                                          currentEori: String,
                                          params: Params,
                                          searchRequests: Set[SearchRequest],
-                                         expireAt:DateTime = DateTime.now()) {
+                                         expireAt:Option[DateTime] = None) {
   require(searchRequests.nonEmpty, "searchRequests is empty")
 }
 

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -120,6 +120,10 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
     updateDocumentForQueryFilter(queryFiler, updates)
   }
 
+  /**
+   * Updates the resultsFound status to the provided updatedStatus
+   * for the given searchID
+   */
   def updateResultsFoundStatus(searchID: String,
                                updatedStatus: SearchResultStatus.Value):Future[Option[HistoricDocumentRequestSearch]] = {
     val queryFiler = Filters.equal(searchIDFieldKey, searchID)

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -16,8 +16,8 @@
 
 package services.cache
 
-import com.mongodb.client.model.FindOneAndUpdateOptions
 import com.mongodb.client.model.Indexes.ascending
+import com.mongodb.client.model.{FindOneAndUpdateOptions, ReturnDocument}
 import config.AppConfig
 import models.{HistoricDocumentRequestSearch, Params, SearchRequest, SearchResultStatus}
 import org.mongodb.scala.bson.conversions.Bson
@@ -25,7 +25,9 @@ import org.mongodb.scala.model.Filters.equal
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Updates}
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.{Codecs, PlayMongoRepository}
+import utils.Utils
 
+import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,13 +41,10 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
     domainFormat = HistoricDocumentRequestSearch.historicDocumentRequestSearchFormat,
     indexes = Seq(
       IndexModel(
-        ascending("currentEori"),
-        IndexOptions()
-          .name("CurrentEoriIndex")
-          .unique(false)
-          .sparse(false)
-          .expireAfter(appConfig.mongoHistDocSearchTtl, TimeUnit.SECONDS).background(true)
-      ), IndexModel(
+        ascending("expireAt"),
+        IndexOptions().name("dataExpiry_idx").expireAfter(appConfig.mongoHistDocSearchTtl, TimeUnit.SECONDS).background(true)
+      ),
+      IndexModel(
         ascending("searchID"),
         IndexOptions()
           .name("SearchIDIndex")
@@ -65,9 +64,13 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
   private val searchRequestsFieldKey = "searchRequests"
   private val currentEoriFieldKey = "currentEori"
   private val statementRequestIdFieldKey = "searchRequests.statementRequestId"
+  private val  resultsFoundFieldKey = "resultsFound"
+  private val searchStatusUpdateDateFieldKey = "searchStatusUpdateDate"
 
   def insertDocument(req: HistoricDocumentRequestSearch): Future[Boolean] =
-    collection.insertOne(req).toFuture() map { _ => false } recover { case _ => true }
+    collection.insertOne(req.copy(
+      expireAt = req.expireAt.plusSeconds(appConfig.mongoHistDocSearchTtl.toInt))
+    ).toFuture() map { _ => false } recover { case _ => true }
 
   def retrieveDocumentsForCurrentEori(currentEori: String): Future[Seq[HistoricDocumentRequestSearch]] =
     collection.find(equal(currentEoriFieldKey, currentEori)).toFuture() recover {
@@ -93,7 +96,7 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
     collection.findOneAndUpdate(
       filter = queryFilter,
       update = updates,
-      new FindOneAndUpdateOptions().upsert(false)).headOption().recover {
+      new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER).upsert(false)).headOption().recover {
       case exception =>
         logger.error(s"Failed to update the document and error is ::: ${exception.getMessage}")
         None
@@ -108,6 +111,18 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
 
     val queryFiler = Filters.equal(searchIDFieldKey, searchID)
     val updates = Updates.set(searchRequestsFieldKey, searchRequests)
+
+    updateDocumentForQueryFilter(queryFiler, updates)
+  }
+
+  def updateResultsFoundStatus(searchID: String,
+                               updatedStatus: SearchResultStatus.Value):Future[Option[HistoricDocumentRequestSearch]] = {
+    val queryFiler = Filters.equal(searchIDFieldKey, searchID)
+
+    val updates = Updates.combine(
+      Updates.set(resultsFoundFieldKey, updatedStatus.toString),
+      Updates.set(searchStatusUpdateDateFieldKey, Utils.dateTimeAsIso8601(LocalDateTime.now))
+    )
 
     updateDocumentForQueryFilter(queryFiler, updates)
   }

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -71,9 +71,9 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
   def insertDocument(req: HistoricDocumentRequestSearch): Future[Boolean] = {
     val expireAtTS = req.expireAt.fold(DateTime.now())(identity).plusSeconds(appConfig.mongoHistDocSearchTtl.toInt)
 
-    collection.insertOne(req.copy(
-      expireAt = Option(expireAtTS))
-    ).toFuture() map { _ => false } recover { case _ => true }
+    collection.insertOne(req.copy(expireAt = Option(expireAtTS))).toFuture() map { _ => false } recover {
+      case _ => true
+    }
   }
 
   def retrieveDocumentsForCurrentEori(currentEori: String): Future[Seq[HistoricDocumentRequestSearch]] =

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -43,7 +43,8 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
     indexes = Seq(
       IndexModel(
         ascending("expireAt"),
-        IndexOptions().name("dataExpiry_idx").expireAfter(appConfig.mongoHistDocSearchTtl, TimeUnit.SECONDS).background(true)
+        IndexOptions().name("dataExpiry_idx").expireAfter(
+          appConfig.mongoHistDocSearchTtl, TimeUnit.SECONDS).background(true)
       ),
       IndexModel(
         ascending("searchID"),
@@ -69,7 +70,7 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
   private val searchStatusUpdateDateFieldKey = "searchStatusUpdateDate"
 
   def insertDocument(req: HistoricDocumentRequestSearch): Future[Boolean] = {
-    val expireAtTS = req.expireAt.fold(DateTime.now())(identity).plusSeconds(appConfig.mongoHistDocSearchTtl.toInt)
+    val expireAtTS = DateTime.now().plusSeconds(appConfig.mongoHistDocSearchTtl.toInt)
 
     collection.insertOne(req.copy(expireAt = Option(expireAtTS))).toFuture() map { _ => false } recover {
       case _ => true

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -68,7 +68,12 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
       req.searchID.toString)
   }
 
-  def updateResultsFoundStatus(req: HistoricDocumentRequestSearch):Future[Option[HistoricDocumentRequestSearch]] = {
+  /**
+   * Updates the resultsFound status to no if all the searchRequests have no for
+   * searchSuccessful field
+   */
+  def updateResultsFoundStatusToNoIfEligible(req: HistoricDocumentRequestSearch
+                                            ):Future[Option[HistoricDocumentRequestSearch]] = {
   val isAllSearchRequestsSearchStatusNo: Boolean = !req.searchRequests.exists(
     sr => sr.searchSuccessful == SearchResultStatus.inProcess || sr.searchSuccessful == SearchResultStatus.yes)
 

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -67,4 +67,14 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
       updatedSearchRequests,
       req.searchID.toString)
   }
+
+  def updateResultsFoundStatus(req: HistoricDocumentRequestSearch):Future[Option[HistoricDocumentRequestSearch]] = {
+  val isAllSearchRequestsHaveSearchStatusNo: Boolean = !req.searchRequests.exists(
+    sr => sr.searchSuccessful == SearchResultStatus.inProcess || sr.searchSuccessful == SearchResultStatus.yes)
+
+    if(isAllSearchRequestsHaveSearchStatusNo)
+      historicDocRequestCache.updateResultsFoundStatus(req.searchID.toString, SearchResultStatus.no)
+    else
+      Future(Option(req))
+  }
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -69,10 +69,10 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
   }
 
   def updateResultsFoundStatus(req: HistoricDocumentRequestSearch):Future[Option[HistoricDocumentRequestSearch]] = {
-  val isAllSearchRequestsHaveSearchStatusNo: Boolean = !req.searchRequests.exists(
+  val isAllSearchRequestsSearchStatusNo: Boolean = !req.searchRequests.exists(
     sr => sr.searchSuccessful == SearchResultStatus.inProcess || sr.searchSuccessful == SearchResultStatus.yes)
 
-    if(isAllSearchRequestsHaveSearchStatusNo)
+    if(isAllSearchRequestsSearchStatusNo)
       historicDocRequestCache.updateResultsFoundStatus(req.searchID.toString, SearchResultStatus.no)
     else
       Future(Option(req))

--- a/test/models/StatementSearchFailureNotificationMetadataSpec.scala
+++ b/test/models/StatementSearchFailureNotificationMetadataSpec.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, Json}
 import utils.SpecBase
 
 class StatementSearchFailureNotificationMetadataSpec extends SpecBase {

--- a/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
@@ -148,7 +148,6 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
 
   "updateResultsFoundStatusToNoIfEligible" should {
     "update the resultsFound to no if all the search requests have no for searchSuccessful field" in new Setup {
-      val statReqId = "5b89895-f0da-4472-af5a-d84d340e7mn5"
       val searchFailureReasonCode = "AWSUnreachable"
       val searchDtTime: String = Utils.dateTimeAsIso8601(LocalDateTime.now)
 

--- a/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
@@ -146,7 +146,7 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
     }
   }
 
-  "updateResultsFoundStatus" should {
+  "updateResultsFoundStatusToNoIfEligible" should {
     "update the resultsFound to no if all the search requests have no for searchSuccessful field" in new Setup {
       val statReqId = "5b89895-f0da-4472-af5a-d84d340e7mn5"
       val searchFailureReasonCode = "AWSUnreachable"
@@ -172,7 +172,7 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
       val service: HistoricDocumentRequestSearchCacheService =
         app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
 
-      service.updateResultsFoundStatus(histDocSearchWithAllSearchRequestsProcessed).map {
+      service.updateResultsFoundStatusToNoIfEligible(histDocSearchWithAllSearchRequestsProcessed).map {
         optDoc => {
           val doc = optDoc.get
 
@@ -190,7 +190,7 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
       val service: HistoricDocumentRequestSearchCacheService =
         app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
 
-      service.updateResultsFoundStatus(histDocRequestSearch).map {
+      service.updateResultsFoundStatusToNoIfEligible(histDocRequestSearch).map {
         optDoc => {
           val doc = optDoc.get
 
@@ -212,7 +212,7 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
           Utils.dateTimeAsIso8601(LocalDateTime.now), "AWSUnreachable", 0)
       )
 
-      service.updateResultsFoundStatus(histDocRequestSearch.copy(searchRequests = searchRequestsOb)).map {
+      service.updateResultsFoundStatusToNoIfEligible(histDocRequestSearch.copy(searchRequests = searchRequestsOb)).map {
         optDoc => {
           val doc = optDoc.get
 

--- a/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
@@ -146,6 +146,83 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
     }
   }
 
+  "updateResultsFoundStatus" should {
+    "update the resultsFound to no if all the search requests have no for searchSuccessful field" in new Setup {
+      val statReqId = "5b89895-f0da-4472-af5a-d84d340e7mn5"
+      val searchFailureReasonCode = "AWSUnreachable"
+      val searchDtTime: String = Utils.dateTimeAsIso8601(LocalDateTime.now)
+
+      val updatedSearchRequests: Set[SearchRequest] = searchRequests.map {
+        sr =>
+          sr.copy(
+            searchSuccessful = SearchResultStatus.no,
+            searchDateTime = searchDtTime,
+            searchFailureReasonCode = searchFailureReasonCode)
+      }
+
+      val histDocSearchWithAllSearchRequestsProcessed: HistoricDocumentRequestSearch =
+        histDocRequestSearch.copy(searchRequests = updatedSearchRequests)
+
+      when(mockHistDocReqSearchCache.updateResultsFoundStatus(
+        histDocSearchWithAllSearchRequestsProcessed.searchID.toString,
+        SearchResultStatus.no
+      )).thenReturn(Future.successful(
+        Option(histDocRequestSearch.copy(searchRequests = updatedSearchRequests))))
+
+      val service: HistoricDocumentRequestSearchCacheService =
+        app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
+
+      service.updateResultsFoundStatus(histDocSearchWithAllSearchRequestsProcessed).map {
+        optDoc => {
+          val doc = optDoc.get
+
+          doc.resultsFound mustBe SearchResultStatus.no
+          doc.searchStatusUpdateDate must not be empty
+        }
+      }
+
+      verify(mockHistDocReqSearchCache, times(1)).updateResultsFoundStatus(
+        histDocSearchWithAllSearchRequestsProcessed.searchID.toString,
+        SearchResultStatus.no)
+    }
+
+    "not update the resultsFound if all the search requests do not have no for searchSuccessful field" in new Setup {
+      val service: HistoricDocumentRequestSearchCacheService =
+        app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
+
+      service.updateResultsFoundStatus(histDocRequestSearch).map {
+        optDoc => {
+          val doc = optDoc.get
+
+          doc.resultsFound mustBe SearchResultStatus.inProcess
+          doc.searchStatusUpdateDate mustBe empty
+        }
+      }
+    }
+
+    "not update the resultsFound to no if one or more search requests do not have no for searchSuccessful field" in new Setup {
+      val service: HistoricDocumentRequestSearchCacheService =
+        app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
+
+      val searchRequestsOb: Set[SearchRequest] = Set(
+        SearchRequest(
+          "GB123456789012", "5b89895-f0da-4472-af5a-d84d340e7mn5", SearchResultStatus.inProcess, emptyString, emptyString, 0),
+        SearchRequest(
+          "GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6", SearchResultStatus.no,
+          Utils.dateTimeAsIso8601(LocalDateTime.now), "AWSUnreachable", 0)
+      )
+
+      service.updateResultsFoundStatus(histDocRequestSearch.copy(searchRequests = searchRequestsOb)).map {
+        optDoc => {
+          val doc = optDoc.get
+
+          doc.resultsFound mustBe SearchResultStatus.inProcess
+          doc.searchStatusUpdateDate mustBe empty
+        }
+      }
+    }
+  }
+
   trait Setup {
     val mockHistDocReqSearchCache: HistoricDocumentRequestSearchCache =
       mock[HistoricDocumentRequestSearchCache]


### PR DESCRIPTION
Description - Code changes to update the resultsFound status to no if all the serachRequests have been processed

Below has been done as part if this PR

- new tests and update to existing tests
- Relevant code changes
- Add new index (name - dataExpiry_idx) as TTL index
- Minor refactoring