### PR TITLE
[MMCA-4220] - Update SDES notification for historic statement service

### DIFF
--- a/app/controllers/metadata/MetadataController.scala
+++ b/app/controllers/metadata/MetadataController.scala
@@ -17,19 +17,21 @@
 package controllers.metadata
 
 import connectors.{DataStoreConnector, EmailThrottlerConnector}
-import domain.{Notification, NotificationsForEori, SDESInputFormats}
+import domain.SDESInputFormats._
+import domain.{Notification, NotificationsForEori}
+import models.{EmailTemplate, SearchResultStatus}
 import play.api.libs.json._
 import play.api.mvc.{Action, ControllerComponents}
 import play.api.{Logger, LoggerLike}
 import play.mvc.Http
+import services.cache.HistoricDocumentRequestSearchCacheService
 import services.{DateTimeService, NotificationCache}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import utils.Utils.emptyString
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-import SDESInputFormats._
-import models.EmailTemplate
 
 
 @Singleton
@@ -38,6 +40,7 @@ class MetadataController @Inject()(
                                     emailThrottlerConnector: EmailThrottlerConnector,
                                     dataStore: DataStoreConnector,
                                     dateTimeService: DateTimeService,
+                                    histDocReqSearchCacheService: HistoricDocumentRequestSearchCacheService,
                                     cc: ControllerComponents
                                   )(implicit execution: ExecutionContext) extends BackendController(cc) {
 
@@ -47,12 +50,46 @@ class MetadataController @Inject()(
     val notifications = req.body
     for {
       _ <- Future.successful(log.info(s"addNotifications: $notifications"))
-      _ <- Future.sequence(notifications.map(sendEmailIfVerified))
+      _ <- Future.sequence(notifications.map(checkHistDocSearchStatusAndSendEmail))
       _ <- Future.sequence(notifications.groupBy(_.eori).map { case (k, v) =>
         notificationCache.putNotifications(NotificationsForEori(k, v, Some(dateTimeService.utcDateTime)))
       })
       result <- Future.successful(Ok(Json.obj("Status" -> "Ok")).as(Http.MimeTypes.JSON))
     } yield result
+  }
+
+  /**
+   * Checks the resultsFound status of the HistoricDocumentRequestSearch document
+   * If resultsFound is inProcess
+   * Update the searchSuccessful status to yes and searchDateTime for the relevant searchRequest for statementRequestId
+   * Update resultsFound to yes along with searchStatusUpdateDate
+   * send the email
+   * else no updates and does not send any email
+   */
+  private def checkHistDocSearchStatusAndSendEmail(notification: Notification)(
+    implicit hc: HeaderCarrier): Future[Boolean] = {
+    val statementRequestID = notification.metadata.getOrElse("statementRequestID", emptyString)
+
+    if (statementRequestID.nonEmpty) {
+      val result = for {
+        optHisDocReq <- histDocReqSearchCacheService.retrieveHistDocRequestSearchDocForStatementReqId(statementRequestID)
+      } yield {
+        optHisDocReq match {
+          case Some(histDocReq) =>
+            if (histDocReq.resultsFound == SearchResultStatus.inProcess) {
+              val emailSentResult: Future[Boolean] = {
+                histDocReqSearchCacheService.processSDESNotificationForStatReqId(histDocReq, statementRequestID)
+                log.info(s"sending email for statementRequestID ::: $statementRequestID")
+                sendEmailIfVerified(notification)
+              }
+              emailSentResult
+            } else Future(false)
+          case _ => Future(false)
+        }
+      }
+
+      result.flatten
+    } else sendEmailIfVerified(notification)
   }
 
   private def sendEmailIfVerified(notification: Notification)(implicit hc: HeaderCarrier): Future[Boolean] = {
@@ -61,7 +98,9 @@ class MetadataController @Inject()(
         val maybeEmailRequest = EmailTemplate.fromNotification(emailAddress, notification)
         maybeEmailRequest match {
           case Some(value) => emailThrottlerConnector.sendEmail(value.toEmailRequest)
-          case None => log.info("No end month/end year supplied from the metadata"); Future.successful(false)
+          case None =>
+            log.info("No end month/end year supplied from the metadata")
+            Future.successful(false)
         }
       case None =>
         log.info(s"unable to obtain a verified email address for user: ${notification.eori}")
@@ -72,4 +111,5 @@ class MetadataController @Inject()(
         false
     }
   }
+
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -135,4 +135,22 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
 
     updateDocumentForQueryFilter(queryFiler, updates)
   }
+
+  /**
+   * Updates the resultsFound status and  searchRequests to the provided values
+   * for the given searchID
+   */
+  def updateSearchReqsAndResultsFoundStatus(searchID: String,
+                                            searchRequests: Set[SearchRequest],
+                                            updatedStatus: SearchResultStatus.Value): Future[Option[HistoricDocumentRequestSearch]] = {
+    val queryFiler = Filters.equal(searchIDFieldKey, searchID)
+
+    val updates = Updates.combine(
+      Updates.set(searchRequestsFieldKey, searchRequests),
+      Updates.set(resultsFoundFieldKey, updatedStatus.toString),
+      Updates.set(searchStatusUpdateDateFieldKey, Utils.dateTimeAsIso8601(LocalDateTime.now))
+    )
+
+    updateDocumentForQueryFilter(queryFiler, updates)
+  }
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -82,4 +82,28 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
     else
       Future(Option(req))
   }
+
+  /**
+   * Updates the searchRequest (for given statementRequestID) in searchRequests field of the Document
+   * for given HistoricDocumentRequestSearch Document
+   */
+  def processSDESNotificationForStatReqId(req: HistoricDocumentRequestSearch,
+                                          statementRequestID: String):
+  Future[Option[HistoricDocumentRequestSearch]] = {
+
+    val updatedSearchRequests: Set[SearchRequest] = req.searchRequests.map {
+      sr =>
+        if (sr.statementRequestId.equals(statementRequestID) &&
+          sr.searchSuccessful == SearchResultStatus.inProcess)
+          sr.copy(
+            searchSuccessful = SearchResultStatus.yes,
+            searchDateTime = Utils.dateTimeAsIso8601(LocalDateTime.now)
+          ) else sr
+    }
+
+    historicDocRequestCache.updateSearchReqsAndResultsFoundStatus(req.searchID.toString,
+      updatedSearchRequests,
+      SearchResultStatus.yes)
+  }
+
 }

--- a/test/controllers/metadata/MetadataControllerSpec.scala
+++ b/test/controllers/metadata/MetadataControllerSpec.scala
@@ -469,7 +469,6 @@ class MetadataControllerSpec extends SpecBase {
       }
     }
 
-
     "send email when a requested PVAT statement is available" in new Setup {
       val requestedPVATStatementNotificationRequest: JsValue = Json.parse(
         s"""
@@ -567,7 +566,6 @@ class MetadataControllerSpec extends SpecBase {
         Future.successful(Option(histDocRequestSearch))
       )
 
-
       running(app) {
         val req: FakeRequest[AnyContentAsJson] =
           FakeRequest(POST, "/metadata").withJsonBody(requestedPVATStatementNotificationRequest)
@@ -584,7 +582,6 @@ class MetadataControllerSpec extends SpecBase {
           None,
           None)
 
-        //verify(mockEmailThrottler).sendEmail(is(expectedEmailRequest))(any)
         verify(mockEmailThrottler, Mockito.times(1)).sendEmail(is(expectedEmailRequest))(any)
         verify(mockDataStore, Mockito.times(1)).getVerifiedEmail(any)(any)
       }
@@ -686,10 +683,10 @@ class MetadataControllerSpec extends SpecBase {
     val currentEori: String = "GB123456789012"
     val params: Params = Params("2", "2021", "4", "2021", "DutyDefermentStatement", "1234567")
     val searchRequests: Set[SearchRequest] = Set(
-      SearchRequest(
-        "GB123456789012", "1abcdefg2-a2b1-abcd-abcd-0123456789", SearchResultStatus.inProcess, emptyString, emptyString, 0),
-      SearchRequest(
-        "GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6", SearchResultStatus.inProcess, emptyString, emptyString, 0)
+      SearchRequest("GB123456789012", "1abcdefg2-a2b1-abcd-abcd-0123456789",
+        SearchResultStatus.inProcess, emptyString, emptyString, 0),
+      SearchRequest("GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6",
+        SearchResultStatus.inProcess, emptyString, emptyString, 0)
     )
 
     val histDocRequestSearch: HistoricDocumentRequestSearch =
@@ -700,6 +697,4 @@ class MetadataControllerSpec extends SpecBase {
         params,
         searchRequests)
   }
-
-
 }

--- a/test/controllers/metadata/MetadataControllerSpec.scala
+++ b/test/controllers/metadata/MetadataControllerSpec.scala
@@ -18,10 +18,10 @@ package controllers.metadata
 
 import connectors.{DataStoreConnector, EmailThrottlerConnector}
 import controllers.CustomAuthConnector
+import models._
 import models.requests.EmailRequest
-import models.{EORI, EmailAddress, NoAssociatedDataException}
-import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{eq => is}
+import org.mockito.{ArgumentMatchers, Mockito}
 import play.api.http.Status.BAD_REQUEST
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, JsValue, Json}
@@ -30,8 +30,11 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.{Application, inject}
 import services.NotificationCache
+import services.cache.{HistoricDocumentRequestSearchCache, HistoricDocumentRequestSearchCacheService}
 import utils.SpecBase
+import utils.Utils.emptyString
 
+import java.util.UUID
 import scala.concurrent.Future
 
 class MetadataControllerSpec extends SpecBase {
@@ -86,7 +89,6 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("test@test.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
-
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, "/metadata").withJsonBody(dd4emailRequest)
         val result = route(app, req).value
@@ -122,6 +124,12 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("foo@bar.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch)))
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
 
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, controllers.metadata.routes.MetadataController.addNotifications().url).withJsonBody(newFileNotificationFromSDES)
@@ -157,6 +165,12 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("foo@bar.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch)))
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
 
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, controllers.metadata.routes.MetadataController.addNotifications().url).withJsonBody(newFileNotificationFromSDES)
@@ -321,6 +335,12 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("test@test.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch)))
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
 
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, "/metadata").withJsonBody(historicC79CertificateNotificationRequest)
@@ -396,6 +416,12 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("test@test.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch)))
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
 
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, "/metadata").withJsonBody(requestedSecurityStatementNotificationRequest)
@@ -472,6 +498,12 @@ class MetadataControllerSpec extends SpecBase {
         .thenReturn(Future.successful(Some(EmailAddress("test@test.com"))))
       when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
 
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch)))
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
 
       running(app) {
         val req: FakeRequest[AnyContentAsJson] = FakeRequest(POST, "/metadata").withJsonBody(requestedPVATStatementNotificationRequest)
@@ -479,6 +511,82 @@ class MetadataControllerSpec extends SpecBase {
         status(result) mustBe OK
         val expectedEmailRequest = EmailRequest(List(EmailAddress("test@test.com")), "customs_financials_requested_postponed_vat_notification", Map.empty[String, String], force = false, Some("testEORI"), None, None)
         verify(mockEmailThrottler).sendEmail(is(expectedEmailRequest))(any)
+      }
+    }
+
+    "send the email only once in case of multiple notifications for same statementRequestID" in new Setup {
+      val requestedPVATStatementNotificationRequest: JsValue = Json.parse(
+        s"""
+           |[
+           |    {
+           |        "eori":"testEORI",
+           |		     "fileName": "vat-2018-05.pdf",
+           |        "fileSize": 75251,
+           |        "metadata": [
+           |            {"metadata": "PeriodStartYear", "value": "2017"},
+           |            {"metadata": "PeriodStartMonth", "value": "5"},
+           |            {"metadata": "PeriodStartDay", "value": "5"},
+           |            {"metadata": "PeriodEndYear", "value": "2018"},
+           |            {"metadata": "PeriodEndMonth", "value": "6"},
+           |            {"metadata": "PeriodEndDay", "value": "5"},
+           |            {"metadata": "FileType", "value": "PDF"},
+           |            {"metadata": "FileRole", "value": "PostponedVATStatement"},
+           |            {"metadata": "statementRequestID", "value": "1abcdefg2-a2b1-abcd-abcd-0123456789"}
+           |        ]
+           |    },
+           |    {
+           |        "eori":"testEORI",
+           |		     "fileName": "vat-2018-05.pdf",
+           |        "fileSize": 75251,
+           |        "metadata": [
+           |            {"metadata": "PeriodStartYear", "value": "2017"},
+           |            {"metadata": "PeriodStartMonth", "value": "7"},
+           |            {"metadata": "PeriodStartDay", "value": "7"},
+           |            {"metadata": "PeriodEndYear", "value": "2018"},
+           |            {"metadata": "PeriodEndMonth", "value": "8"},
+           |            {"metadata": "PeriodEndDay", "value": "5"},
+           |            {"metadata": "FileType", "value": "PDF"},
+           |            {"metadata": "FileRole", "value": "PostponedVATStatement"},
+           |            {"metadata": "statementRequestID", "value": "1abcdefg2-a2b1-abcd-abcd-0123456789"}
+           |        ]
+           |    }
+           |]
+        """.stripMargin)
+
+      when(mockEmailThrottler.sendEmail(any)(any)).thenReturn(Future.successful(true))
+      when(mockDataStore.getVerifiedEmail(any)(any))
+        .thenReturn(Future.successful(Some(EmailAddress("test@test.com"))))
+      when(mockNotificationCache.putNotifications(any)).thenReturn(Future.successful(()))
+
+      when(mockHistDocReqCacheService.retrieveHistDocRequestSearchDocForStatementReqId(any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))).andThenAnswer(
+        Future.successful(Option(histDocRequestSearch.copy(resultsFound = SearchResultStatus.yes)))
+      )
+
+      when(mockHistDocReqCacheService.processSDESNotificationForStatReqId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch))
+      )
+
+
+      running(app) {
+        val req: FakeRequest[AnyContentAsJson] =
+          FakeRequest(POST, "/metadata").withJsonBody(requestedPVATStatementNotificationRequest)
+
+        val result = route(app, req).value
+        status(result) mustBe OK
+
+        val expectedEmailRequest = EmailRequest(
+          List(EmailAddress("test@test.com")),
+          "customs_financials_requested_postponed_vat_notification",
+          Map.empty[String, String],
+          force = false,
+          Some("testEORI"),
+          None,
+          None)
+
+        //verify(mockEmailThrottler).sendEmail(is(expectedEmailRequest))(any)
+        verify(mockEmailThrottler, Mockito.times(1)).sendEmail(is(expectedEmailRequest))(any)
+        verify(mockDataStore, Mockito.times(1)).getVerifiedEmail(any)(any)
       }
     }
 
@@ -508,12 +616,16 @@ class MetadataControllerSpec extends SpecBase {
     val mockEmailThrottler: EmailThrottlerConnector = mock[EmailThrottlerConnector]
     val mockAuthConnector: CustomAuthConnector = mock[CustomAuthConnector]
     val mockDataStore: DataStoreConnector = mock[DataStoreConnector]
+    val mockHistDocReqCacheService = mock[HistoricDocumentRequestSearchCacheService]
+    val mockHistDocReqCache = mock[HistoricDocumentRequestSearchCache]
 
     val app: Application = GuiceApplicationBuilder().overrides(
       inject.bind[CustomAuthConnector].toInstance(mockAuthConnector),
       inject.bind[NotificationCache].toInstance(mockNotificationCache),
       inject.bind[EmailThrottlerConnector].toInstance(mockEmailThrottler),
-      inject.bind[DataStoreConnector].toInstance(mockDataStore)
+      inject.bind[DataStoreConnector].toInstance(mockDataStore),
+      inject.bind[HistoricDocumentRequestSearchCacheService].toInstance(mockHistDocReqCacheService),
+      inject.bind[HistoricDocumentRequestSearchCache].toInstance(mockHistDocReqCache)
     ).configure(
       "microservice.metrics.enabled" -> false,
       "metrics.enabled" -> false,
@@ -566,6 +678,27 @@ class MetadataControllerSpec extends SpecBase {
         |    }
         |]
       """.stripMargin))
+
+    val searchID: UUID = UUID.randomUUID()
+    val userId: String = "test_userId"
+    val resultsFound: SearchResultStatus.Value = SearchResultStatus.inProcess
+    val searchStatusUpdateDate: String = emptyString
+    val currentEori: String = "GB123456789012"
+    val params: Params = Params("2", "2021", "4", "2021", "DutyDefermentStatement", "1234567")
+    val searchRequests: Set[SearchRequest] = Set(
+      SearchRequest(
+        "GB123456789012", "1abcdefg2-a2b1-abcd-abcd-0123456789", SearchResultStatus.inProcess, emptyString, emptyString, 0),
+      SearchRequest(
+        "GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6", SearchResultStatus.inProcess, emptyString, emptyString, 0)
+    )
+
+    val histDocRequestSearch: HistoricDocumentRequestSearch =
+      HistoricDocumentRequestSearch(searchID,
+        resultsFound,
+        searchStatusUpdateDate,
+        currentEori,
+        params,
+        searchRequests)
   }
 
 

--- a/test/services/cache/HistoricDocumentRequestSearchCacheSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheSpec.scala
@@ -293,6 +293,47 @@ class HistoricDocumentRequestSearchCacheSpec extends SpecBase
     }
   }
 
+  "updateSearchReqsAndResultsFoundStatus" should {
+    "update the document correctly" in {
+      val updatedDateTime = Utils.dateTimeAsIso8601(LocalDateTime.now)
+
+      val updatedSearchRequests = Set(
+        SearchRequest(
+          "GB123456789012", "5b89895-f0da-4472-af5a-d84d340e7mn5", SearchResultStatus.yes,
+          updatedDateTime, "AWSUnreachable", 0),
+        SearchRequest(
+          "GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6",
+          SearchResultStatus.no, updatedDateTime, "NoDocumentsFound", 0)
+      )
+
+      val docToBeInserted = getHistoricDocumentRequestSearchDoc
+
+      val documentsInDB = for {
+        _ <- historicDocumentRequestCache.collection.drop().toFuture()
+        _ <- historicDocumentRequestCache.insertDocument(docToBeInserted)
+        updatedDoc <- historicDocumentRequestCache.updateSearchReqsAndResultsFoundStatus(
+          docToBeInserted.searchID.toString,
+          updatedSearchRequests,
+          SearchResultStatus.yes)
+      } yield updatedDoc
+
+      whenReady(documentsInDB) {
+        documentsInDB =>
+          val updateDoc = documentsInDB.get
+          documentsInDB.get.currentEori mustBe "GB123456789012"
+
+          val searchRequestAfterUpdate = documentsInDB.get.searchRequests.find(
+            sr => sr.statementRequestId == "5b89895-f0da-4472-af5a-d84d340e7mn5").get
+
+          searchRequestAfterUpdate.searchSuccessful mustBe SearchResultStatus.yes
+          searchRequestAfterUpdate.searchDateTime must not be empty
+
+          updateDoc.resultsFound mustBe SearchResultStatus.yes
+          updateDoc.searchStatusUpdateDate must not be empty
+      }
+    }
+  }
+
   private def getHistoricDocumentRequestSearchDoc: HistoricDocumentRequestSearch = {
     val searchID: UUID = UUID.randomUUID()
     val resultsFound = SearchResultStatus.inProcess


### PR DESCRIPTION
Description - Code changes to update the historic request search mongo document and send the email once for multiple requests for same statementRequestID

Below has been done as part of this PR

- New tests and update the existing tests
- Relevant code changes
- Minor refactoring