### PR TITLE
[MMCA-4219] - Retry ACC24 request on technical failure

### DIFF
--- a/app/controllers/StatementSearchFailureNotificationController.scala
+++ b/app/controllers/StatementSearchFailureNotificationController.scala
@@ -207,7 +207,8 @@ class StatementSearchFailureNotificationController @Inject()(
       }
       NoContent
     }
-    else InternalServerError(buildInternalServerErrorResponse(correlationId, statementRequestID))
+    else InternalServerError(buildInternalServerErrorResponse(
+      correlationId, statementRequestID, ErrorMessage.failureRetryCountErrorDetail(statementRequestID)))
   }
 
   private def isSearchRequestIsInProcess(optHistDocReqSearchDoc: HistoricDocumentRequestSearch,
@@ -229,17 +230,25 @@ class StatementSearchFailureNotificationController @Inject()(
     }
 
   private def buildInternalServerErrorResponse(correlationId: String,
-                                               statementRequestID: String) =
+                                               statementRequestID: String,
+                                               errorDetailMessage: String = emptyString) =
     buildErrorResponse(
       errorCode = ErrorCode.code500,
       correlationId = correlationId,
-      statementReqId = Some(statementRequestID))
+      statementReqId = Some(statementRequestID),
+      errorDetailMsg = errorDetailMessage)
 
   private def buildErrorResponse(errors: Option[Throwable] = None,
                                  errorCode: String = ErrorCode.code400,
                                  correlationId: String,
-                                 statementReqId: Option[String] = None) = {
-    val errorResponse = StatementSearchFailureNotificationErrorResponse(errors, errorCode, correlationId, statementReqId)
+                                 statementReqId: Option[String] = None,
+                                 errorDetailMsg: String = emptyString) = {
+    val errorResponse = StatementSearchFailureNotificationErrorResponse(
+      errors,
+      errorCode,
+      correlationId,
+      statementReqId,
+      errorDetailMsg)
 
     jsonSchemaValidator.validatePayload(Json.toJson(errorResponse), jsonSchemaValidator.ssfnErrorResponseSchema) match {
       case Success(_) => errorResponse

--- a/app/controllers/StatementSearchFailureNotificationController.scala
+++ b/app/controllers/StatementSearchFailureNotificationController.scala
@@ -117,16 +117,14 @@ class StatementSearchFailureNotificationController @Inject()(
       if (failureReasonCode != "NoDocumentsFound")
         Future(updateRetryCountAndSendRequest(correlationId, statementRequestID, failureReasonCode, optHistDocReq.get))
       else
-        updateHistoricDocumentRequestSearchForStatReqId(
-          correlationId, statementRequestID, failureReasonCode, optHistDocReq.get)
+        updateHistoricDocumentRequestSearchForStatReqId(statementRequestID, failureReasonCode, optHistDocReq.get)
     }
   }
 
-  private def updateHistoricDocumentRequestSearchForStatReqId(correlationId: String,
-                                                              statementRequestID: String,
+  private def updateHistoricDocumentRequestSearchForStatReqId(statementRequestID: String,
                                                               failureReasonCode: String,
-                                                              optHistDocReqSearchDoc: HistoricDocumentRequestSearch)(
-                                                               implicit hc: HeaderCarrier): Future[Result] = {
+                                                              optHistDocReqSearchDoc: HistoricDocumentRequestSearch
+                                                             ): Future[Result] = {
     for {
       updatedHistDoc <- updateSearchRequestIfInProcess(statementRequestID,
         failureReasonCode, optHistDocReqSearchDoc)
@@ -202,7 +200,8 @@ class StatementSearchFailureNotificationController @Inject()(
           histDocReqSearchDoc.searchRequests)
       } yield {
         histDocumentService.sendHistoricDocumentRequest(
-          HistoricDocumentRequest(statementRequestID, optHistDoc.get))
+          HistoricDocumentRequest(statementRequestID, optHistDoc.getOrElse(
+            throw new RuntimeException("HistoricDocumentRequestSearch could not be retrieved"))))
       }
       NoContent
     }

--- a/app/controllers/StatementSearchFailureNotificationController.scala
+++ b/app/controllers/StatementSearchFailureNotificationController.scala
@@ -170,6 +170,10 @@ class StatementSearchFailureNotificationController @Inject()(
     else
       Future(None)
 
+  private def updateRetryCountAndSendRequest() = {
+
+  }
+
   private def isSearchRequestIsInProcess(optHistDocReqSearchDoc: Option[HistoricDocumentRequestSearch],
                                          statementRequestID: String) =
     optHistDocReqSearchDoc.fold(false)(

--- a/app/models/FailureReason.scala
+++ b/app/models/FailureReason.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+object FailureReason  {
+  val NO_DOCUMENTS_FOUND = "NoDocumentsFound"
+  val DOCUMENTUM_UNREACHABLE = "DocumentumUnreachable"
+  val DOCUMENT_EXCEPTION = "DocumentumException"
+  val AWS_UNREACHABLE = "AWSUnreachable"
+  val AWS_EXCEPTION =  "AWSException"
+  val BAD_REQUEST_RECEIVED = "BadRequestReceived"
+  val CDDM_INTERNAL_ERROR = "CDDMInternalError"
+}

--- a/app/models/FailureRetryCount.scala
+++ b/app/models/FailureRetryCount.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+object FailureRetryCount {
+  val FIRST_RETRY = 1
+  val SECOND_RETRY = 2
+  val THIRD_RETRY = 3
+  val FOURTH_RETRY = 4
+  val FINAL_RETRY = 5
+}

--- a/app/models/requests/HistoricDocumentRequest.scala
+++ b/app/models/requests/HistoricDocumentRequest.scala
@@ -37,7 +37,6 @@ object HistoricDocumentRequest {
 
   def apply(statementRequestID: String,
             histDocRequestSearch: HistoricDocumentRequestSearch): HistoricDocumentRequest = {
-
     val searchReqForStatReqId: SearchRequest =
       histDocRequestSearch.searchRequests.find(
         sr => sr.statementRequestId == statementRequestID).getOrElse(

--- a/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
+++ b/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
@@ -120,7 +120,8 @@ object ErrorMessage {
     statementReqId => s"Technical error occurred while processing the statementRequestId : $statementReqId"
 
   def failureRetryCountErrorDetail: String => String =
-    statementReqId => s"Failure retry count has reached its maximum value for statementRequestId : $statementReqId"
+    statementReqId =>
+      s"Failure retry count has reached its maximum permitted value for statementRequestId : $statementReqId"
 }
 
 object ErrorSource {

--- a/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
+++ b/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
@@ -120,7 +120,7 @@ object ErrorMessage {
     statementReqId => s"Technical error occurred while processing the statementRequestId : $statementReqId"
 
   def failureRetryCountErrorDetail: String => String =
-    statementReqId => s"Failure retry count has reached its max value for statementRequestId : $statementReqId"
+    statementReqId => s"Failure retry count has reached its maximum value for statementRequestId : $statementReqId"
 }
 
 object ErrorSource {

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -68,7 +68,6 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
   private val statementRequestIdFieldKey = "searchRequests.statementRequestId"
   private val  resultsFoundFieldKey = "resultsFound"
   private val searchStatusUpdateDateFieldKey = "searchStatusUpdateDate"
-  private val searchFailureReasonCodeKey = "searchFailureReasonCode"
 
   def insertDocument(req: HistoricDocumentRequestSearch): Future[Boolean] = {
     val expireAtTS = DateTime.now().plusSeconds(appConfig.mongoHistDocSearchTtl.toInt)

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -155,16 +155,4 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
     updateDocumentForQueryFilter(queryFiler, updates)
   }
 
-  def updateSearchRequestRetryCount(searchID: String,
-                                    searchRequests: Set[SearchRequest],
-                                    failureReason: String): Future[Option[HistoricDocumentRequestSearch]] = {
-    val queryFiler = Filters.equal(searchIDFieldKey, searchID)
-
-    val updates = Updates.combine(
-      Updates.set(searchRequestsFieldKey, searchRequests),
-      Updates.set(searchFailureReasonCodeKey, failureReason)
-    )
-
-    updateDocumentForQueryFilter(queryFiler, updates)
-  }
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -142,7 +142,8 @@ class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
    */
   def updateSearchReqsAndResultsFoundStatus(searchID: String,
                                             searchRequests: Set[SearchRequest],
-                                            updatedStatus: SearchResultStatus.Value): Future[Option[HistoricDocumentRequestSearch]] = {
+                                            updatedStatus: SearchResultStatus.Value
+                                           ): Future[Option[HistoricDocumentRequestSearch]] = {
     val queryFiler = Filters.equal(searchIDFieldKey, searchID)
 
     val updates = Updates.combine(

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -106,6 +106,10 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
       SearchResultStatus.yes)
   }
 
+  /**
+   * Updates the searchRequest's searchFailureReasonCode and increment failureRetryCount by one
+   * for the provided statementRequestID
+   */
   def updateSearchRequestRetryCount(statementRequestID: String,
                                     failureReason: String,
                                     searchId: String,
@@ -118,10 +122,9 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
         else sr
     }
 
-    historicDocRequestCache.updateSearchRequestRetryCount(
-      searchId,
+    historicDocRequestCache.updateSearchRequestForStatementRequestId(
       updatedSearchRequests,
-      failureReason)
+      searchId)
   }
 
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -106,4 +106,22 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
       SearchResultStatus.yes)
   }
 
+  def updateSearchRequestRetryCount(statementRequestID: String,
+                                    failureReason: String,
+                                    searchId: String,
+                                    searchRequests: Set[SearchRequest]): Future[Option[HistoricDocumentRequestSearch]] = {
+    val updatedSearchRequests = searchRequests.map {
+      sr =>
+        if (sr.statementRequestId == statementRequestID &&
+          sr.searchSuccessful == SearchResultStatus.inProcess)
+          sr.copy(searchFailureReasonCode = failureReason, failureRetryCount = sr.failureRetryCount + 1)
+        else sr
+    }
+
+    historicDocRequestCache.updateSearchRequestRetryCount(
+      searchId,
+      updatedSearchRequests,
+      failureReason)
+  }
+
 }

--- a/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCacheService.scala
@@ -113,7 +113,8 @@ class HistoricDocumentRequestSearchCacheService @Inject()(historicDocRequestCach
   def updateSearchRequestRetryCount(statementRequestID: String,
                                     failureReason: String,
                                     searchId: String,
-                                    searchRequests: Set[SearchRequest]): Future[Option[HistoricDocumentRequestSearch]] = {
+                                    searchRequests: Set[SearchRequest]
+                                   ): Future[Option[HistoricDocumentRequestSearch]] = {
     val updatedSearchRequests = searchRequests.map {
       sr =>
         if (sr.statementRequestId == statementRequestID &&

--- a/test/controllers/StatementSearchFailureNotificationControllerSpec.scala
+++ b/test/controllers/StatementSearchFailureNotificationControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.SecureMessageConnector
 import models._
 import models.requests.StatementSearchFailureNotificationRequest
 import models.requests.StatementSearchFailureNotificationRequest.ssfnRequestFormat
-import models.responses.{ErrorCode, StatementSearchFailureNotificationErrorResponse}
+import models.responses.{ErrorCode, ErrorMessage, StatementSearchFailureNotificationErrorResponse}
 import org.mockito.Mockito
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT, UNAUTHORIZED}
 import play.api.libs.json.{JsObject, Json}
@@ -181,7 +181,8 @@ class StatementSearchFailureNotificationControllerSpec extends SpecBase {
         status(response) mustBe INTERNAL_SERVER_ERROR
 
         contentAsJson(response) mustBe Json.toJson(StatementSearchFailureNotificationErrorResponse(
-          None, ErrorCode.code500, correlationId, Option(incomingStatementReqId)))
+          None, ErrorCode.code500, correlationId, Option(incomingStatementReqId),
+          ErrorMessage.failureRetryCountErrorDetail(incomingStatementReqId)))
       }
 
       verify(mockHistDocReqSearchCacheService, Mockito.times(1))

--- a/test/controllers/StatementSearchFailureNotificationControllerSpec.scala
+++ b/test/controllers/StatementSearchFailureNotificationControllerSpec.scala
@@ -20,7 +20,7 @@ import connectors.SecureMessageConnector
 import models._
 import models.requests.StatementSearchFailureNotificationRequest
 import models.requests.StatementSearchFailureNotificationRequest.ssfnRequestFormat
-import models.responses.StatementSearchFailureNotificationErrorResponse
+import models.responses.{ErrorCode, StatementSearchFailureNotificationErrorResponse}
 import org.mockito.Mockito
 import play.api.http.Status.{BAD_REQUEST, INTERNAL_SERVER_ERROR, NO_CONTENT, UNAUTHORIZED}
 import play.api.libs.json.{JsObject, Json}
@@ -50,7 +50,7 @@ class StatementSearchFailureNotificationControllerSpec extends SpecBase {
         status(response) mustBe BAD_REQUEST
 
         contentAsJson(response) mustBe Json.toJson(StatementSearchFailureNotificationErrorResponse(
-          None, correlationId, Option(incomingStatementReqId)))
+          None, ErrorCode.code400, correlationId, Option(incomingStatementReqId)))
       }
     }
 

--- a/test/models/requests/HistoricDocumentRequestSpec.scala
+++ b/test/models/requests/HistoricDocumentRequestSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+import models._
+import utils.SpecBase
+import utils.Utils.emptyString
+
+import java.util.UUID
+
+class HistoricDocumentRequestSpec extends SpecBase {
+
+  "apply" should {
+    "create the object correctly" in new Setup {
+      HistoricDocumentRequest(incomingStatementReqId, historicDocumentRequestSearchDoc) mustBe
+        HistoricDocumentRequest(
+          eori = EORI(eoriNumber),
+          documentType = FileRole(accountType),
+          periodStartMonth = 2,
+          periodStartYear = 2021,
+          periodEndMonth = 4,
+          periodEndYear = 2021,
+          dan = Some(dan),
+          statementRequestID = UUID.fromString(incomingStatementReqId)
+        )
+    }
+  }
+
+  trait Setup {
+    val incomingStatementReqId: String = UUID.randomUUID().toString
+    val eoriNumber = "GB123456789012"
+    val accountType = "DutyDefermentStatement"
+    val dan = "1234567"
+    val searchID: UUID = UUID.randomUUID()
+    val resultsFound: SearchResultStatus.Value = SearchResultStatus.inProcess
+    val searchStatusUpdateDate: String = emptyString
+    val currentEori: String = "GB123456789012"
+    val params: Params = Params("2", "2021", "4", "2021", "DutyDefermentStatement", dan)
+    val searchRequests: Set[SearchRequest] = Set(
+      SearchRequest(
+        eoriNumber, incomingStatementReqId, SearchResultStatus.inProcess, emptyString, emptyString, 0),
+      SearchRequest(
+        "GB234567890121", "5c79895-f0da-4472-af5a-d84d340e7mn6", SearchResultStatus.inProcess,
+        emptyString, emptyString, 0)
+    )
+
+    val historicDocumentRequestSearchDoc: HistoricDocumentRequestSearch =
+      HistoricDocumentRequestSearch(searchID,
+        resultsFound,
+        searchStatusUpdateDate,
+        currentEori,
+        params,
+        searchRequests)
+  }
+}

--- a/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
+++ b/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
@@ -272,7 +272,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
     "return correct output" in {
       val statementReqId = "test_id"
       ErrorMessage.failureRetryCountErrorDetail(statementReqId) mustBe
-        s"Failure retry count has reached its max value for statementRequestId : $statementReqId"
+        s"Failure retry count has reached its maximum permitted value for statementRequestId : $statementReqId"
     }
   }
 

--- a/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
+++ b/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
@@ -50,7 +50,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
 
       val schemaErrorMsg = "(: object has missing required properties ([\"StatementSearchFailureNotificationMetadata\"]))"
       val actualOb = StatementSearchFailureNotificationErrorResponse(
-        Option(new BadRequestException(schemaErrorMsg)), correlationId)
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code400, correlationId)
 
       actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
       actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
@@ -79,7 +79,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
       val schemaErrorMsg = "(/StatementSearchFailureNotificationMetadata:" +
         " object has missing required properties ([\"reason\",\"statementRequestID\"]))"
       val actualOb = StatementSearchFailureNotificationErrorResponse(
-        Option(new BadRequestException(schemaErrorMsg)), correlationId)
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code400, correlationId)
 
       actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
       actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
@@ -109,7 +109,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
       val schemaErrorMsg = "(/StatementSearchFailureNotificationMetadata/statementRequestID:" +
         " ECMA 262 regex \"^[A-Fa-f0-9-]{36}$\" does not match input string \"1641bd46\")"
       val actualOb = StatementSearchFailureNotificationErrorResponse(
-        Option(new BadRequestException(schemaErrorMsg)), correlationId)
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code400, correlationId)
 
       actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
       actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
@@ -147,7 +147,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
         "\"AWSUnreachable\",\"AWSException\",\"BadRequestReceived\",\"CDDMInternalError\"]))"
 
       val actualOb = StatementSearchFailureNotificationErrorResponse(
-        Option(new BadRequestException(schemaErrorMsg)), correlationId)
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code400, correlationId)
 
       actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
       actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
@@ -158,7 +158,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
     }
 
     "create the object correctly with errorCode, errorMessage, source and sourceFaultDetail " +
-      "when statementRequestID is present in the " in new Setup {
+      "when statementRequestID is present" in new Setup {
       val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e"
       val statementReqId = "9041cc6e-9afb-42ad-b4f1-f017d884fc17"
 
@@ -176,7 +176,7 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
       val schemaErrorMsg = ""
 
       val actualOb = StatementSearchFailureNotificationErrorResponse(
-        Option(new BadRequestException(schemaErrorMsg)), correlationId, Option(statementReqId))
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code400, correlationId, Option(statementReqId))
 
       actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
       actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
@@ -187,6 +187,54 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
 
       actualOb.errorDetail.sourceFaultDetail.detail.head mustBe
         expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.head
+    }
+
+    "create the object correctly with errorCode, errorMessage, source and sourceFaultDetail " +
+      "for technical error and statementRequestId is present " in new Setup {
+      val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e"
+      val statementReqId = "9041cc6e-9afb-42ad-b4f1-f017d884fc17"
+
+      val sourceFaultDetail = SourceFaultDetail(Seq(ErrorMessage.technicalErrorDetail(statementReqId)))
+
+      val errorDetail = ErrorDetail(Utils.currentDateTimeAsRFC7231(LocalDateTime.now()),
+        correlationId,
+        errorCode = ErrorCode.code500,
+        errorMessage = ErrorMessage.technicalError,
+        source = ErrorSource.cdsFinancials,
+        sourceFaultDetail = sourceFaultDetail)
+
+      val expectedSSFNErrorResOb = StatementSearchFailureNotificationErrorResponse(errorDetail)
+
+      val schemaErrorMsg = ""
+
+      val actualOb = StatementSearchFailureNotificationErrorResponse(
+        Option(new BadRequestException(schemaErrorMsg)), ErrorCode.code500, correlationId, Option(statementReqId))
+
+      actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
+      actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
+      actualOb.errorDetail.source mustBe expectedSSFNErrorResOb.errorDetail.source
+      actualOb.errorDetail.errorMessage mustBe expectedSSFNErrorResOb.errorDetail.errorMessage
+      actualOb.errorDetail.sourceFaultDetail.detail.size mustBe
+        expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.size
+
+      actualOb.errorDetail.sourceFaultDetail.detail.head mustBe
+        expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.head
+    }
+  }
+
+  "ErrorMessage.technicalErrorDetail" should {
+    "return correct output" in {
+      val statementReqId = "test_id"
+      ErrorMessage.technicalErrorDetail(statementReqId) mustBe
+        s"Technical error occurred while processing the statementRequestId : $statementReqId"
+    }
+  }
+
+  "ErrorMessage.invalidStatementReqIdDetail" should {
+    "return correct output" in {
+      val statementReqId = "test_id"
+      ErrorMessage.invalidStatementReqIdDetail(statementReqId) mustBe
+        s"statementRequestId : $statementReqId is not recognised"
     }
   }
 

--- a/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
+++ b/test/models/responses/StatementSearchFailureNotificationErrorResponseSpec.scala
@@ -220,6 +220,44 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
       actualOb.errorDetail.sourceFaultDetail.detail.head mustBe
         expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.head
     }
+
+    "create the object correctly with errorCode, errorMessage, source and sourceFaultDetail " +
+      "for technical error when statementRequestId and errorDetailMsg are present " in new Setup {
+      val correlationId = "3jh1f6b3-f8b1-4f3c-973a-05b4720e"
+      val statementReqId = "9041cc6e-9afb-42ad-b4f1-f017d884fc17"
+
+      val sourceFaultDetail: SourceFaultDetail =
+        SourceFaultDetail(Seq(ErrorMessage.failureRetryCountErrorDetail(statementReqId)))
+
+      val errorDetail: ErrorDetail = ErrorDetail(Utils.currentDateTimeAsRFC7231(LocalDateTime.now()),
+        correlationId,
+        errorCode = ErrorCode.code500,
+        errorMessage = ErrorMessage.technicalError,
+        source = ErrorSource.cdsFinancials,
+        sourceFaultDetail = sourceFaultDetail)
+
+      val expectedSSFNErrorResOb: StatementSearchFailureNotificationErrorResponse =
+        StatementSearchFailureNotificationErrorResponse(errorDetail)
+
+      val schemaErrorMsg = ""
+
+      val actualOb: StatementSearchFailureNotificationErrorResponse = StatementSearchFailureNotificationErrorResponse(
+        Option(new BadRequestException(schemaErrorMsg)),
+        ErrorCode.code500,
+        correlationId,
+        Option(statementReqId),
+        ErrorMessage.failureRetryCountErrorDetail(statementReqId))
+
+      actualOb.errorDetail.errorCode mustBe expectedSSFNErrorResOb.errorDetail.errorCode
+      actualOb.errorDetail.correlationId mustBe expectedSSFNErrorResOb.errorDetail.correlationId
+      actualOb.errorDetail.source mustBe expectedSSFNErrorResOb.errorDetail.source
+      actualOb.errorDetail.errorMessage mustBe expectedSSFNErrorResOb.errorDetail.errorMessage
+      actualOb.errorDetail.sourceFaultDetail.detail.size mustBe
+        expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.size
+
+      actualOb.errorDetail.sourceFaultDetail.detail.head mustBe
+        expectedSSFNErrorResOb.errorDetail.sourceFaultDetail.detail.head
+    }
   }
 
   "ErrorMessage.technicalErrorDetail" should {
@@ -227,6 +265,14 @@ class StatementSearchFailureNotificationErrorResponseSpec extends SpecBase {
       val statementReqId = "test_id"
       ErrorMessage.technicalErrorDetail(statementReqId) mustBe
         s"Technical error occurred while processing the statementRequestId : $statementReqId"
+    }
+  }
+
+  "ErrorMessage.failureRetryCountErrorDetail" should {
+    "return correct output" in {
+      val statementReqId = "test_id"
+      ErrorMessage.failureRetryCountErrorDetail(statementReqId) mustBe
+        s"Failure retry count has reached its max value for statementRequestId : $statementReqId"
     }
   }
 

--- a/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
@@ -120,10 +120,8 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
             searchFailureReasonCode = searchFailureReasonCode) else sr
       }
 
-      when(mockHistDocReqSearchCache.updateSearchRequestForStatementRequestId(
-        updatedSearchRequests,
-        searchID.toString)).thenReturn(Future.successful(
-        Option(histDocRequestSearch.copy(searchRequests = updatedSearchRequests))))
+      when(mockHistDocReqSearchCache.updateSearchRequestForStatementRequestId(any, any)).thenReturn(
+        Future.successful(Option(histDocRequestSearch.copy(searchRequests = updatedSearchRequests))))
 
       val service: HistoricDocumentRequestSearchCacheService =
         app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]

--- a/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
+++ b/test/services/cache/HistoricDocumentRequestSearchCacheServiceSpec.scala
@@ -265,6 +265,50 @@ class HistoricDocumentRequestSearchCacheServiceSpec extends SpecBase {
     }
   }
 
+  "updateSearchRequestRetryCount" should {
+    "update the doc correctly" in new Setup {
+
+      val statReqId = "5b89895-f0da-4472-af5a-d84d340e7mn5"
+      val searchFailureReasonCode = "AWSUnreachable"
+      //val searchDtTime: String = Utils.dateTimeAsIso8601(LocalDateTime.now)
+
+      val updatedSearchRequests: Set[SearchRequest] = searchRequests.map {
+        sr =>
+          if (sr.statementRequestId.equals(statReqId)) sr.copy(
+            searchFailureReasonCode = searchFailureReasonCode,
+            failureRetryCount = sr.failureRetryCount + 1) else sr
+      }
+
+      when(mockHistDocReqSearchCache.updateSearchRequestForStatementRequestId(
+        updatedSearchRequests,
+        searchID.toString)).thenReturn(Future.successful(
+        Option(histDocRequestSearch.copy(searchRequests = updatedSearchRequests))))
+
+      val service: HistoricDocumentRequestSearchCacheService =
+        app.injector.instanceOf[HistoricDocumentRequestSearchCacheService]
+
+      service.updateSearchRequestRetryCount(
+        statReqId,
+        searchFailureReasonCode,
+        searchID.toString,
+        histDocRequestSearch.searchRequests
+        ).map {
+        optDoc => {
+          val doc = optDoc.get
+          val updatedSR = doc.searchRequests.find(x => x.statementRequestId == statReqId).get
+
+          doc.searchID.toString mustBe searchID.toString
+          updatedSR.searchFailureReasonCode mustBe searchFailureReasonCode
+          updatedSR.searchSuccessful mustBe SearchResultStatus.inProcess
+          updatedSR.failureRetryCount mustBe 1
+        }
+      }
+
+      verify(mockHistDocReqSearchCache, times(1)).updateSearchRequestForStatementRequestId(
+        updatedSearchRequests, searchID.toString)
+    }
+  }
+
   trait Setup {
     val mockHistDocReqSearchCache: HistoricDocumentRequestSearchCache =
       mock[HistoricDocumentRequestSearchCache]


### PR DESCRIPTION
Description - Code changes to implement the failure retry count mechanism when reason is other than NoDocumentsFound

Below is done as part of this PR

- New tests and updated existing tests
- relevant code changes
- Two new objects for FailureRetryCount and FailureReason
- Minor refactoring