### PR TITLE
[MMCA-4299] - Update the links in secure message body

### DIFF
--- a/app/domain/secureMessage/Body.scala
+++ b/app/domain/secureMessage/Body.scala
@@ -18,7 +18,7 @@ package domain.secureMessage
 
 import models.Params
 import play.api.libs.json.{Json, OFormat}
-import utils.Utils.{convertMonthValueToFullMonthName, englishLangKey, singleSpace, welshLangKey}
+import utils.Utils._
 
 case class Body(eori: String)
 
@@ -96,19 +96,29 @@ object SecureMessage {
   val YouRequestedFor = "you requested for"
 
   def DutyDefermentBody(companyName: String,
-                        dateRange: DateRange): String = s"Dear ${companyName}<br/><br/>" +
-    s"The duty deferment statements ${YouRequestedFor} ${dateRange.message}" +
-    s"${WereNotFound}${TwoReasons}" +
-    s"${ImportVATCerts} ${MadeUsingCustoms}" +
-    " You can get duty deferment statements for declarations made using CHIEF" +
-    s" from Duty Deferment Electronic Statements (DDES).<br/></li></ol>${SignOff}"
+                        dateRange: DateRange): String = {
+    val guidanceLinkText = "Duty Deferment Electronic Statements (DDES)"
+    val guidanceLink = "https://secure.hmce.gov.uk/ecom/login/index.html"
+
+    s"Dear ${companyName}<br/><br/>" +
+      s"The duty deferment statements ${YouRequestedFor} ${dateRange.message}" +
+      s"${WereNotFound}${TwoReasons}" +
+      s"${ImportVATCerts} ${MadeUsingCustoms}" +
+      " You can get duty deferment statements for declarations made using CHIEF" +
+      s" from ${createHyperLink(guidanceLinkText, guidanceLink)}.<br/></li></ol>${SignOff}"
+  }
 
   def C79CertificateBody(companyName: String,
-                         dateRange: DateRange): String = s"Dear ${companyName}<br/><br/>" +
-    s"The import VAT certificates ${YouRequestedFor} ${dateRange.message}" +
-    s"${WereNotFound}${TwoReasons}${ImportVATCerts} ${MadeUsingCustoms}" +
-    s"${CheckIfYourDeclarations} cbc-c79requests@hmrc.gov.uk to" +
-    s"${RequestChief}</li></ol>${SignOff}"
+                         dateRange: DateRange): String = {
+    val guidanceLinkText = "cbc-c79requests@hmrc.gov.uk"
+    val guidanceLink = "mailto:cbc-c79requests@hmrc.gov.uk"
+
+    s"Dear ${companyName}<br/><br/>" +
+      s"The import VAT certificates ${YouRequestedFor} ${dateRange.message}" +
+      s"${WereNotFound}${TwoReasons}${ImportVATCerts} ${MadeUsingCustoms}" +
+      s"${CheckIfYourDeclarations} ${createHyperLink(guidanceLinkText, guidanceLink)} to" +
+      s"${RequestChief}</li></ol>${SignOff}"
+  }
 
   def SecurityBody(companyName: String,
                    dateRange: DateRange): String = s"Dear ${companyName}<br/><br/>" +
@@ -118,12 +128,17 @@ object SecureMessage {
     s" (Insert guidance on how to get CHIEF NOA statements).<br/></li></ol>${SignOff}"
 
   def PostponedVATBody(companyName: String,
-                       dateRange: DateRange): String = s"Dear ${companyName}<br/><br/>" +
-    s"The postponed import VAT statements ${YouRequestedFor} ${dateRange.message}" +
-    s"${WereNotFound}${TwoReasons}" +
-    s"<li>Postponed import VAT statements for declarations ${MadeUsingCustoms}" +
-    s"${CheckIfYourDeclarations} pvaenquiries@hmrc.gov.uk to" +
-    s"${RequestChief}</li></ol>${SignOff}"
+                       dateRange: DateRange): String = {
+    val guidanceLinkText = "pvaenquiries@hmrc.gov.uk"
+    val guidanceLink = "mailto:pvaenquiries@hmrc.gov.uk"
+
+    s"Dear ${companyName}<br/><br/>" +
+      s"The postponed import VAT statements ${YouRequestedFor} ${dateRange.message}" +
+      s"${WereNotFound}${TwoReasons}" +
+      s"<li>Postponed import VAT statements for declarations ${MadeUsingCustoms}" +
+      s"${CheckIfYourDeclarations} ${createHyperLink(guidanceLinkText, guidanceLink)} to" +
+      s"${RequestChief}</li></ol>${SignOff}"
+  }
 
   val DutyDefermentTemplate = "customs_financials_requested_duty_deferment_not_found"
   val C79CertificateTemplate = "customs_financials_requested_c79_certificate_not_found"

--- a/app/services/cache/HistoricDocumentRequestSearchCache.scala
+++ b/app/services/cache/HistoricDocumentRequestSearchCache.scala
@@ -30,9 +30,9 @@ import utils.Utils
 
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-
+@Singleton
 class HistoricDocumentRequestSearchCache @Inject()(appConfig: AppConfig,
                                                    mongoComponent: MongoComponent)
                                                   (implicit val ec: ExecutionContext)

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -91,4 +91,14 @@ object Utils {
       "12" -> (if (lang == welshLangKey) "December" else "December")
     )
 
+  /**
+   * Creates the inline html for hyperLink with given text, link and style class
+   */
+  def createHyperLink(text: String,
+                      link: String,
+                      styleClass: String = "govuk-link"): String = {
+    val doubleQuotes = "\""
+
+    s"<a class=$doubleQuotes$styleClass$doubleQuotes href=$doubleQuotes$link$doubleQuotes>$text</a>"
+  }
 }

--- a/test/domain/secureMessage/BodySpec.scala
+++ b/test/domain/secureMessage/BodySpec.scala
@@ -213,7 +213,8 @@ class BodySpec extends SpecBase {
       "<li>Import VAT certificates for declarations made using Customs Handling " +
       "of Import and Export Freight (CHIEF) cannot be requested using the Customs " +
       "Declaration Service. You can get duty deferment statements for declarations" +
-      " made using CHIEF from Duty Deferment Electronic Statements (DDES).<br/>" +
+      " made using CHIEF from <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
+      "Duty Deferment Electronic Statements (DDES)</a>.<br/>" +
       "</li></ol>From the Customs Declaration Service"
 
     val TestC79CertificateBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
@@ -223,7 +224,8 @@ class BodySpec extends SpecBase {
       " the dates you requested.</li><br/><li>Import VAT certificates for declarations made" +
       " using Customs Handling of Import and Export Freight (CHIEF) cannot be requested using" +
       " the Customs Declaration Service. Check if your declarations were made using CHIEF and" +
-      " contact cbc-c79requests@hmrc.gov.uk to request CHIEF statements.<br/></li></ol>" +
+      " contact <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">" +
+      "cbc-c79requests@hmrc.gov.uk</a> to request CHIEF statements.<br/></li></ol>" +
       "From the Customs Declaration Service"
 
     val TestSecurityBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
@@ -240,21 +242,21 @@ class BodySpec extends SpecBase {
       "periods in which you imported goods. Check that you imported goods during the dates you requested." +
       "</li><br/><li>Postponed import VAT statements for declarations made using Customs Handling of " +
       "Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service. " +
-      "Check if your declarations were made using CHIEF and contact pvaenquiries@hmrc.gov.uk to " +
+      "Check if your declarations were made using CHIEF and contact <a class=\"govuk-link\" href=" +
+      "\"mailto:pvaenquiries@hmrc.gov.uk\">pvaenquiries@hmrc.gov.uk</a> to " +
       "request CHIEF statements.<br/></li></ol>From the Customs Declaration Service"
 
-    val encodedDutyDeferementBody: String = "RGVhciBBcHBsZXMgJiBQZWFycyBMdGQ8YnIvPjxici8+" +
-      "VGhlIGR1dHkgZGVmZXJtZW50IHN0YXRlbWVudHMgeW91IHJlcXVlc3RlZCBmb3IgU2VwdGVtYmVyIDIwMjI" +
-      "gdG8gT2N0b2JlciAyMDIyIHdlcmUgbm90IGZvdW5kLjxici8+PGJyLz5UaGVyZSBhcmUgMiBwb3NzaWJsZS" +
-      "ByZWFzb25zIGZvciB0aGlzOjxici8+PG9sPjxsaT5TdGF0ZW1lbnRzIGFyZSBvbmx5IGNyZWF0ZWQgZm9yI" +
-      "HRoZSBwZXJpb2RzIGluIHdoaWNoIHlvdSBpbXBvcnRlZCBnb29kcy4gQ2hlY2sgdGhhdCB5b3UgaW1wb3J0" +
-      "ZWQgZ29vZHMgZHVyaW5nIHRoZSBkYXRlcyB5b3UgcmVxdWVzdGVkLjwvbGk+PGJyLz48bGk+SW1wb3J0IFZ" +
-      "BVCBjZXJ0aWZpY2F0ZXMgZm9yIGRlY2xhcmF0aW9ucyBtYWRlIHVzaW5nIEN1c3RvbXMgSGFuZGxpbmcgb2" +
-      "YgSW1wb3J0IGFuZCBFeHBvcnQgRnJlaWdodCAoQ0hJRUYpIGNhbm5vdCBiZSByZXF1ZXN0ZWQgdXNpbmcgd" +
-      "GhlIEN1c3RvbXMgRGVjbGFyYXRpb24gU2VydmljZS4gWW91IGNhbiBnZXQgZHV0eSBkZWZlcm1lbnQgc3Rh" +
-      "dGVtZW50cyBmb3IgZGVjbGFyYXRpb25zIG1hZGUgdXNpbmcgQ0hJRUYgZnJvbSBEdXR5IERlZmVybWVudCB" +
-      "FbGVjdHJvbmljIFN0YXRlbWVudHMgKERERVMpLjxici8+PC9saT48L29sPkZyb20gdGhlIEN1c3RvbXMgRG" +
-      "VjbGFyYXRpb24gU2VydmljZQ=="
+    val encodedDutyDeferementBody: String = "RGVhciBBcHBsZXMgJiBQZWFycyBMdGQ8YnIvPjxici8+VGhlIGR1dHkgZGVmZX" +
+      "JtZW50IHN0YXRlbWVudHMgeW91IHJlcXVlc3RlZCBmb3IgU2VwdGVtYmVyIDIwMjIgdG8gT2N0b2JlciAyMDIyIHdlcmUgbm90IGZ" +
+      "vdW5kLjxici8+PGJyLz5UaGVyZSBhcmUgMiBwb3NzaWJsZSByZWFzb25zIGZvciB0aGlzOjxici8+PG9sPjxsaT5TdGF0ZW1lbnRz" +
+      "IGFyZSBvbmx5IGNyZWF0ZWQgZm9yIHRoZSBwZXJpb2RzIGluIHdoaWNoIHlvdSBpbXBvcnRlZCBnb29kcy4gQ2hlY2sgdGhhdCB5b" +
+      "3UgaW1wb3J0ZWQgZ29vZHMgZHVyaW5nIHRoZSBkYXRlcyB5b3UgcmVxdWVzdGVkLjwvbGk+PGJyLz48bGk+SW1wb3J0IFZBVCBjZX" +
+      "J0aWZpY2F0ZXMgZm9yIGRlY2xhcmF0aW9ucyBtYWRlIHVzaW5nIEN1c3RvbXMgSGFuZGxpbmcgb2YgSW1wb3J0IGFuZCBFeHBvcnQg" +
+      "RnJlaWdodCAoQ0hJRUYpIGNhbm5vdCBiZSByZXF1ZXN0ZWQgdXNpbmcgdGhlIEN1c3RvbXMgRGVjbGFyYXRpb24gU2VydmljZS4gWW" +
+      "91IGNhbiBnZXQgZHV0eSBkZWZlcm1lbnQgc3RhdGVtZW50cyBmb3IgZGVjbGFyYXRpb25zIG1hZGUgdXNpbmcgQ0hJRUYgZnJvbSA8" +
+      "YSBjbGFzcz0iZ292dWstbGluayIgaHJlZj0iaHR0cHM6Ly9zZWN1cmUuaG1jZS5nb3YudWsvZWNvbS9sb2dpbi9pbmRleC5odG1sIj5" +
+      "EdXR5IERlZmVybWVudCBFbGVjdHJvbmljIFN0YXRlbWVudHMgKERERVMpPC9hPi48YnIvPjwvbGk+PC9vbD5Gcm9tIHRoZSBDdXN0b21" +
+      "zIERlY2xhcmF0aW9uIFNlcnZpY2U="
 
     val params: Params = Params(periodStartMonth = "02",
       periodStartYear = "2021",

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -186,5 +186,18 @@ class UtilsSpec extends SpecBase {
         }
       }
     }
+
+    "createHyperLink" should {
+      "create the hyperLink with correct link, text and default style class" in {
+
+        createHyperLink("test_text", "test_link@test.com") mustBe
+          "<a class=\"govuk-link\" href=\"test_link@test.com\">test_text</a>"
+      }
+
+      "create the hyperLink with correct link, text and given style class" in {
+        createHyperLink("test_text", "test_link@test.com", "test_class") mustBe
+          "<a class=\"test_class\" href=\"test_link@test.com\">test_text</a>"
+      }
+    }
   }
 }


### PR DESCRIPTION
Description - Code changes to update the guidance link in secure message body

Below has been done as part this PR

- Add new tests and update the existing tests
- Relevant code changes
- Addition of new common method to create the inline hyperLink
- made HistoricDocumentRequestSearchCache as Singleton as there should only be one instance of this
- Very minor refactoring