### PR TITLE
[MMCA-4324] - Secure messages without company name

### DIFF
--- a/app/domain/secureMessage/Body.scala
+++ b/app/domain/secureMessage/Body.scala
@@ -105,6 +105,11 @@ object SecureMessage {
 
   val YouRequestedFor = "you requested for"
 
+  val DutyDefermentTemplate = "customs_financials_requested_duty_deferment_not_found"
+  val C79CertificateTemplate = "customs_financials_requested_c79_certificate_not_found"
+  val SecurityTemplate = "customs_financials_requested_notification_adjustment_statements_not_found"
+  val PostponedVATemplate = "customs_financials_requested_postponed_import_vat_statements_not_found"
+
   def DutyDefermentBody(companyName: String,
                         dateRange: DateRange,
                         lang: String = englishLangKey): String = {
@@ -113,7 +118,7 @@ object SecureMessage {
     if (lang == englishLangKey) {
       val guidanceLinkText = "Duty Deferment Electronic Statements (DDES)"
 
-      s"Dear ${companyName}<br/><br/>" +
+      s"Dear ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"The duty deferment statements ${YouRequestedFor} ${dateRange.dateAsText}" +
         s"${WereNotFound}${TwoReasons}" +
         s"${ImportVATCerts} ${MadeUsingCustoms}" +
@@ -122,7 +127,7 @@ object SecureMessage {
     } else {
       val guidanceLinkText = " Datganiadau Electronig i Ohirio Tollau (DDES)"
 
-      s"Annwyl ${companyName} <br/><br/>" +
+      s"Annwyl ${companyNameForMsg(companyName, lang)} <br/><br/>" +
         s"Ni chafwyd hyd i’r datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis ${dateRange.dateAsText}." +
         s"<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae " +
         s"datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau yn ystod y dyddiadau y" +
@@ -143,14 +148,14 @@ object SecureMessage {
     val guidanceLink = "mailto:cbc-c79requests@hmrc.gov.uk"
 
     if (lang == englishLangKey) {
-      s"Dear ${companyName}<br/><br/>" +
+      s"Dear ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"The import VAT certificates ${YouRequestedFor} ${dateRange.dateAsText}" +
         s"${WereNotFound}${TwoReasons}${ImportVATCerts} ${MadeUsingCustoms}" +
         s"${CheckIfYourDeclarations} ${createHyperLink(guidanceLinkText, guidanceLink)} to" +
         s"${RequestChief}</li></ol>${SignOff}"
     } else {
 
-      s"Annwyl ${companyName}<br/><br/>" +
+      s"Annwyl ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"Ni chafwyd hyd i’r Tystysgrifau TAW mewnforio y gwnaethoch gais amdanynt ar gyfer mis ${dateRange.dateAsText}." +
         s"<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>" +
         s"Dim ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu." +
@@ -169,13 +174,13 @@ object SecureMessage {
                    dateRange: DateRange,
                    lang: String = englishLangKey): String = {
     if (lang == englishLangKey) {
-      s"Dear ${companyName}<br/><br/>" +
+      s"Dear ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"The notification of adjustment statements ${YouRequestedFor} ${dateRange.dateAsText}" +
         s"${WereNotFound}${TwoReasons}" +
         s"<li>Notification of adjustment statements for declarations ${MadeUsingCustoms}" +
         s"<br/></li></ol>${SignOff}"
     } else {
-      s"Annwyl ${companyName}<br/><br/>" +
+      s"Annwyl ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"Ni chafwyd hyd i’r hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer mis" +
         s"${dateRange.dateAsText}." + "<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>" +
         "Dim ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu." +
@@ -194,14 +199,14 @@ object SecureMessage {
     val guidanceLink = "mailto:pvaenquiries@hmrc.gov.uk"
 
     if (lang == englishLangKey) {
-      s"Dear ${companyName}<br/><br/>" +
+      s"Dear ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"The postponed import VAT statements ${YouRequestedFor} ${dateRange.dateAsText}" +
         s"${WereNotFound}${TwoReasons}" +
         s"<li>Postponed import VAT statements for declarations ${MadeUsingCustoms}" +
         s"${CheckIfYourDeclarations} ${createHyperLink(guidanceLinkText, guidanceLink)} to" +
         s"${RequestChief}</li></ol>${SignOff}"
     } else {
-      s"Annwyl ${companyName}<br/><br/>" +
+      s"Annwyl ${companyNameForMsg(companyName, lang)}<br/><br/>" +
         s"Ni chafwyd hyd i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
         s"${dateRange.dateAsText}." + s"<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>" +
         s"Dim ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau ’n cael eu creu." +
@@ -214,10 +219,16 @@ object SecureMessage {
     }
   }
 
-  val DutyDefermentTemplate = "customs_financials_requested_duty_deferment_not_found"
-  val C79CertificateTemplate = "customs_financials_requested_c79_certificate_not_found"
-  val SecurityTemplate = "customs_financials_requested_notification_adjustment_statements_not_found"
-  val PostponedVATemplate = "customs_financials_requested_postponed_import_vat_statements_not_found"
+  /**
+   * Return the company name if non empty
+   * otherwise returns Customer for English or Gwsmer for Welsh
+   */
+  private def companyNameForMsg(companyName: String,
+                                lang: String): String = {
+    if (companyName.isEmpty) {
+      if (lang == englishLangKey) "Customer" else "Gwsmer"
+    } else companyName
+  }
 }
 
 object SecureMessageResponse

--- a/app/domain/secureMessage/Body.scala
+++ b/app/domain/secureMessage/Body.scala
@@ -220,7 +220,7 @@ object SecureMessage {
   }
 
   /**
-   * Return the company name if non empty
+   * Returns the company name if non empty
    * otherwise returns Customer for English or Gwsmer for Welsh
    */
   private def companyNameForMsg(companyName: String,

--- a/test/domain/secureMessage/BodySpec.scala
+++ b/test/domain/secureMessage/BodySpec.scala
@@ -27,33 +27,33 @@ class BodySpec extends SpecBase {
 
   "Case Classes should be populated correctly" should {
     "ExternalReference" in new Setup {
-      val exRef = ExternalReference("id", "source")
+      val exRef: ExternalReference = ExternalReference("id", "source")
       exRef mustBe TestRef
     }
 
     "Body" in new Setup {
-      val body = Body("eori")
+      val body: Body = Body("eori")
       body mustBe TestBody
     }
 
     "Tax" in new Setup {
-      val tax = TaxIdentifier("name", "value")
+      val tax: TaxIdentifier = TaxIdentifier("name", "value")
       tax mustBe TestTax
     }
 
     "Receipient" in new Setup {
-      val tax = TaxIdentifier("name", "value")
-      val recip = Recipient("regime", tax, "Company Name", "test@test.com")
+      val tax: TaxIdentifier = TaxIdentifier("name", "value")
+      val recip: Recipient = Recipient("regime", tax, "Company Name", "test@test.com")
       recip mustBe TestRecip
     }
 
     "Tags" in new Setup {
-      val tags = Tags("NotificationType")
+      val tags: Tags = Tags("NotificationType")
       tags mustBe TestTags
     }
 
     "Content" in new Setup {
-      val content = Content("en", "accountType", "body")
+      val content: Content = Content("en", "accountType", "body")
       content mustBe TestContent
     }
   }
@@ -61,101 +61,111 @@ class BodySpec extends SpecBase {
   "Body Text" should {
     "display DutyDeferementBody correctly" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
-      DutyDefermentBody("Apples & Pears Ltd", dateRange) mustBe TestDutyDefermentBody
+      DutyDefermentBody("Apples & Pears Ltd", dateRange) mustBe TestDutyDefermentBody(applesAndPearsLtd)
     }
 
     "display C79CertificateBody correctly" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
-      C79CertificateBody("Apples & Pears Ltd", dateRange) mustBe TestC79CertificateBody
+      C79CertificateBody("Apples & Pears Ltd", dateRange) mustBe TestC79CertificateBody(applesAndPearsLtd)
     }
 
     "display SecurityBody correctly" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
-      SecurityBody("Apples & Pears Ltd", dateRange) mustBe TestSecurityBody
+      SecurityBody("Apples & Pears Ltd", dateRange) mustBe TestSecurityBody(applesAndPearsLtd)
     }
 
     "display PostponedVATBody correctly" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
-      PostponedVATBody("Apples & Pears Ltd", dateRange) mustBe TestPostponedVATBody
+      PostponedVATBody("Apples & Pears Ltd", dateRange) mustBe TestPostponedVATBody(applesAndPearsLtd)
     }
 
     "display DutyDefermentBody correctly when company name is empty for English" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
-      DutyDefermentBody(emptyString, dateRange) mustBe TestDutyDefermentBodyForEmptyCompanyName
+      DutyDefermentBody(emptyString, dateRange) mustBe TestDutyDefermentBody()
     }
 
     "display C79CertificateBody correctly when company name is empty for English" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
-      C79CertificateBody(emptyString, dateRange) mustBe TestC79CertificateBodyForEmptyCompanyName
+      C79CertificateBody(emptyString, dateRange) mustBe TestC79CertificateBody()
     }
 
     "display SecurityBody correctly when company name is empty for English" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
-      SecurityBody(emptyString, dateRange) mustBe TestSecurityBodyForEmptyCompanyName
+      SecurityBody(emptyString, dateRange) mustBe TestSecurityBody()
     }
 
     "display PostponedVATBody correctly when company name is empty for English" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
-      PostponedVATBody(emptyString, dateRange) mustBe TestPostponedVATBodyForEmptyCompanyName
+      PostponedVATBody(emptyString, dateRange) mustBe TestPostponedVATBody()
     }
 
     "should encode correctly" in new Setup {
-      val res = Utils.encodeToUTF8Charsets(TestDutyDefermentBody)
-      res mustBe encodedDutyDeferementBody
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBody(applesAndPearsLtd)) mustBe encodedDutyDeferementBody
     }
 
     "should encode the body with empty company name correctly for English" in new Setup {
-      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyForEmptyCompanyName) mustBe
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBody()) mustBe
         encodedDutyDefermentBodyForEmptyCompanyName
     }
 
     "display DutyDeferementBody correctly in welsh" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
-      DutyDefermentBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe TestDutyDefermentBodyCy
+      DutyDefermentBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe
+        TestDutyDefermentBodyCy(applesAndPearsLtd)
     }
 
     "display C79CertificateBody correctly in welsh" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
-      C79CertificateBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe TestC79CertificateBodyCy
+      C79CertificateBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe
+        TestC79CertificateBodyCy(applesAndPearsLtd)
     }
 
     "display SecurityBody correctly in welsh" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
-      SecurityBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe TestSecurityBodyCy
+      SecurityBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe
+        TestSecurityBodyCy(applesAndPearsLtd)
     }
 
     "display PostponedVATBody correctly in welsh" in new Setup {
-      override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
-      PostponedVATBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe TestPostponedVATBodyCy
+      override val dateRange: DateRange = DateRange(
+        dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
+
+      PostponedVATBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe
+        TestPostponedVATBodyCy(applesAndPearsLtd)
     }
 
     "display DutyDefermentBody correctly when company name is empty for Welsh" in new Setup {
-      override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
-      DutyDefermentBody(emptyString, dateRange, welshLangKey) mustBe TestDutyDefermentBodyCyWithEmptyCompanyName
+      override val dateRange: DateRange = DateRange(
+        dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
+
+      DutyDefermentBody(emptyString, dateRange, welshLangKey) mustBe TestDutyDefermentBodyCy()
     }
 
     "display C79CertificateBody correctly when company name is empty for Welsh" in new Setup {
-      override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
-      C79CertificateBody(emptyString, dateRange, welshLangKey) mustBe TestC79CertificateBodyCyWithEmptyCompanyName
+      override val dateRange: DateRange = DateRange(
+        dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
+
+      C79CertificateBody(emptyString, dateRange, welshLangKey) mustBe TestC79CertificateBodyCy()
     }
 
     "display SecurityBody correctly when company name is empty for Welsh" in new Setup {
       override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
-      SecurityBody(emptyString, dateRange, welshLangKey) mustBe TestSecurityBodyCyWithEmptyCompanyName
+      SecurityBody(emptyString, dateRange, welshLangKey) mustBe TestSecurityBodyCy()
     }
 
     "display PostponedVATBody correctly when company name is empty for Welsh" in new Setup {
-      override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
-      PostponedVATBody(emptyString, dateRange, welshLangKey) mustBe TestPostponedVATBodyCyWithEmptyCompanyName
+      override val dateRange: DateRange = DateRange(
+        dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
+
+      PostponedVATBody(emptyString, dateRange, welshLangKey) mustBe TestPostponedVATBodyCy()
     }
 
     "should encode correctly in welsh" in new Setup {
-      val res = Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCy)
-      res mustBe encodedDutyDeferementBodyCy
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCy(applesAndPearsLtd)) mustBe encodedDutyDeferementBodyCy
     }
 
     "should encode the body with empty company name correctly for Welsh" in new Setup {
-      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCyWithEmptyCompanyName) mustBe
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCy()) mustBe
         encodedDutyDeferementBodyCyForEmptyCompanyName
     }
 
@@ -291,7 +301,11 @@ class BodySpec extends SpecBase {
     val TestSubjectSecurity: String = "Requested notification of adjustment statements "
     val TestSubjectImport = "Requested postponed import VAT statements "
 
-    val TestDutyDefermentBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
+    val applesAndPearsLtd = "Apples & Pears Ltd"
+    val defaultCompanyName = "Customer"
+    val defaultCompanyNameCy = "Gwsmer"
+
+    def TestDutyDefermentBody(companyName: String = defaultCompanyName): String = s"Dear $companyName<br/><br/>" +
       "The duty deferment statements you requested for September 2022 to October 2022 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>" +
       "Statements are only created for the periods in which you imported goods." +
@@ -303,19 +317,7 @@ class BodySpec extends SpecBase {
       "Duty Deferment Electronic Statements (DDES)</a>.<br/>" +
       "</li></ol>From the Customs Declaration Service"
 
-    val TestDutyDefermentBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
-      "The duty deferment statements you requested for September 2022 to October 2022 were not found." +
-      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>" +
-      "Statements are only created for the periods in which you imported goods." +
-      " Check that you imported goods during the dates you requested.</li><br/>" +
-      "<li>Import VAT certificates for declarations made using Customs Handling " +
-      "of Import and Export Freight (CHIEF) cannot be requested using the Customs " +
-      "Declaration Service. You can get duty deferment statements for declarations" +
-      " made using CHIEF from <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
-      "Duty Deferment Electronic Statements (DDES)</a>.<br/>" +
-      "</li></ol>From the Customs Declaration Service"
-
-    val TestC79CertificateBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
+    def TestC79CertificateBody(companyName: String = defaultCompanyName): String = s"Dear $companyName<br/><br/>" +
       "The import VAT certificates you requested for January 2022 to April 2022 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created " +
       "for the periods in which you imported goods. Check that you imported goods during" +
@@ -326,18 +328,7 @@ class BodySpec extends SpecBase {
       "cbc-c79requests@hmrc.gov.uk</a> to request CHIEF statements.<br/></li></ol>" +
       "From the Customs Declaration Service"
 
-    val TestC79CertificateBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
-      "The import VAT certificates you requested for January 2022 to April 2022 were not found." +
-      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created " +
-      "for the periods in which you imported goods. Check that you imported goods during" +
-      " the dates you requested.</li><br/><li>Import VAT certificates for declarations made" +
-      " using Customs Handling of Import and Export Freight (CHIEF) cannot be requested using" +
-      " the Customs Declaration Service. Check if your declarations were made using CHIEF and" +
-      " contact <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">" +
-      "cbc-c79requests@hmrc.gov.uk</a> to request CHIEF statements.<br/></li></ol>" +
-      "From the Customs Declaration Service"
-
-    val TestSecurityBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
+    def TestSecurityBody(companyName: String = defaultCompanyName): String = s"Dear $companyName<br/><br/>" +
       "The notification of adjustment statements you requested for March 2021 to May 2021 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
       "periods in which you imported goods. Check that you imported goods during the dates you requested." +
@@ -345,25 +336,7 @@ class BodySpec extends SpecBase {
       "of Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service." +
       "<br/></li></ol>From the Customs Declaration Service"
 
-    val TestSecurityBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
-      "The notification of adjustment statements you requested for March 2021 to May 2021 were not found." +
-      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
-      "periods in which you imported goods. Check that you imported goods during the dates you requested." +
-      "</li><br/><li>Notification of adjustment statements for declarations made using Customs Handling " +
-      "of Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service." +
-      "<br/></li></ol>From the Customs Declaration Service"
-
-    val TestPostponedVATBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
-      "The postponed import VAT statements you requested for February 2022 to March 2022 were not found." +
-      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
-      "periods in which you imported goods. Check that you imported goods during the dates you requested." +
-      "</li><br/><li>Postponed import VAT statements for declarations made using Customs Handling of " +
-      "Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service. " +
-      "Check if your declarations were made using CHIEF and contact <a class=\"govuk-link\" href=" +
-      "\"mailto:pvaenquiries@hmrc.gov.uk\">pvaenquiries@hmrc.gov.uk</a> to " +
-      "request CHIEF statements.<br/></li></ol>From the Customs Declaration Service"
-
-    val TestPostponedVATBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
+    def TestPostponedVATBody(companyName: String = defaultCompanyName): String = s"Dear $companyName<br/><br/>" +
       "The postponed import VAT statements you requested for February 2022 to March 2022 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
       "periods in which you imported goods. Check that you imported goods during the dates you requested." +
@@ -398,97 +371,55 @@ class BodySpec extends SpecBase {
       "wiPkR1dHkgRGVmZXJtZW50IEVsZWN0cm9uaWMgU3RhdGVtZW50cyAoRERFUyk8L2E+Ljxici8+PC9saT48L29sPkZyb20gdGhlIEN1c3RvbXMg" +
       "RGVjbGFyYXRpb24gU2VydmljZQ=="
 
-    val TestDutyDefermentBodyCy: String = "Annwyl Apples & Pears Ltd <br/><br/>Ni chafwyd hyd i’r" +
-      " datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis September 2022 to October" +
-      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
-      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
-      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
-      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
-      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u" +
-      " Hallforio (CHIEF). Gallwch ddefnyddio’r gwasanaeth" +
-      " <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
-      " Datganiadau Electronig i Ohirio Tollau (DDES)</a>i gael datganiadau gohirio " +
-      "tollau ar gyfer datganiadau a wnaed gan ddefnyddio’r gwasanaeth CHIEF." +
-      "</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+    def TestDutyDefermentBodyCy(companyName: String = defaultCompanyNameCy): String =
+      s"Annwyl $companyName <br/><br/>Ni chafwyd hyd i’r" +
+        " datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis September 2022 to October" +
+        " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
+        " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
+        " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
+        " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
+        " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u" +
+        " Hallforio (CHIEF). Gallwch ddefnyddio’r gwasanaeth" +
+        " <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
+        " Datganiadau Electronig i Ohirio Tollau (DDES)</a>i gael datganiadau gohirio " +
+        "tollau ar gyfer datganiadau a wnaed gan ddefnyddio’r gwasanaeth CHIEF." +
+        "</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
 
-    val TestDutyDefermentBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer <br/><br/>Ni chafwyd hyd i’r" +
-      " datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis September 2022 to October" +
-      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
-      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
-      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
-      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
-      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u" +
-      " Hallforio (CHIEF). Gallwch ddefnyddio’r gwasanaeth" +
-      " <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
-      " Datganiadau Electronig i Ohirio Tollau (DDES)</a>i gael datganiadau gohirio " +
-      "tollau ar gyfer datganiadau a wnaed gan ddefnyddio’r gwasanaeth CHIEF." +
-      "</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+    def TestC79CertificateBodyCy(companyName: String = defaultCompanyNameCy): String =
+      s"Annwyl $companyName<br/><br/>Ni chafwyd hyd i’r" +
+        " Tystysgrifau TAW mewnforio y gwnaethoch gais amdanynt ar gyfer mis January 2022 to April" +
+        " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
+        " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
+        " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
+        " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
+        " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio" +
+        " (CHIEF).Gwiriwch os cafodd eich datganiadau eu gwneud drwy ddefnyddio CHIEF a chysylltwch â" +
+        " <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">cbc-c79requests@hmrc.gov.uk</a>" +
+        " i wneud cais am ddatganiadau CHIEF.</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
 
-    val TestC79CertificateBodyCy: String = "Annwyl Apples & Pears Ltd<br/><br/>Ni chafwyd hyd i’r" +
-      " Tystysgrifau TAW mewnforio y gwnaethoch gais amdanynt ar gyfer mis January 2022 to April" +
-      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
-      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
-      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
-      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
-      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio" +
-      " (CHIEF).Gwiriwch os cafodd eich datganiadau eu gwneud drwy ddefnyddio CHIEF a chysylltwch â" +
-      " <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">cbc-c79requests@hmrc.gov.uk</a>" +
-      " i wneud cais am ddatganiadau CHIEF.</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+    def TestSecurityBodyCy(companyName: String = defaultCompanyNameCy): String =
+      s"Annwyl $companyName<br/><br/>Ni chafwyd hyd i’r" +
+        " hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer misMarch 2021 to" +
+        " May 2021.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y" +
+        " gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu.Gwiriwch eich bod wedi" +
+        " mewnforio nwyddau yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni" +
+        " ellir defnyddio’r Gwasanaeth Datganiadau Tollau (CDS) i wneud cais am hysbysiad o" +
+        " ddatganiadau addasu ar gyfer datganiadau a wnaed gan ddefnyddio system y Tollau ar" +
+        " gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio (CHIEF).</li></ol><br/>Oddi" +
+        " wrth y Gwasanaeth Datganiadau Tollau"
 
-    val TestC79CertificateBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd i’r" +
-      " Tystysgrifau TAW mewnforio y gwnaethoch gais amdanynt ar gyfer mis January 2022 to April" +
-      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
-      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
-      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
-      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
-      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio" +
-      " (CHIEF).Gwiriwch os cafodd eich datganiadau eu gwneud drwy ddefnyddio CHIEF a chysylltwch â" +
-      " <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">cbc-c79requests@hmrc.gov.uk</a>" +
-      " i wneud cais am ddatganiadau CHIEF.</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
-
-    val TestSecurityBodyCy: String = "Annwyl Apples & Pears Ltd<br/><br/>Ni chafwyd hyd i’r" +
-      " hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer misMarch 2021 to" +
-      " May 2021.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y" +
-      " gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu.Gwiriwch eich bod wedi" +
-      " mewnforio nwyddau yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni" +
-      " ellir defnyddio’r Gwasanaeth Datganiadau Tollau (CDS) i wneud cais am hysbysiad o" +
-      " ddatganiadau addasu ar gyfer datganiadau a wnaed gan ddefnyddio system y Tollau ar" +
-      " gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio (CHIEF).</li></ol><br/>Oddi" +
-      " wrth y Gwasanaeth Datganiadau Tollau"
-
-    val TestSecurityBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd i’r" +
-      " hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer misMarch 2021 to" +
-      " May 2021.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y" +
-      " gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu.Gwiriwch eich bod wedi" +
-      " mewnforio nwyddau yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni" +
-      " ellir defnyddio’r Gwasanaeth Datganiadau Tollau (CDS) i wneud cais am hysbysiad o" +
-      " ddatganiadau addasu ar gyfer datganiadau a wnaed gan ddefnyddio system y Tollau ar" +
-      " gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio (CHIEF).</li></ol><br/>Oddi" +
-      " wrth y Gwasanaeth Datganiadau Tollau"
-
-    val TestPostponedVATBodyCy: String = "Annwyl Apples & Pears Ltd<br/><br/>Ni chafwyd hyd" +
-      " i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
-      "February 2022 to March 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim" +
-      " ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau" +
-      " ’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau yn ystod y dyddiadau" +
-      " y gwnaethoch gais amdanynt.</li><br/>Ni ellir defnyddio’r Gwasanaeth Datganiadau" +
-      " Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio gohiriedig ar gyfer" +
-      " datganiadau a wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a" +
-      " Gaiff eu Mewnforio a’u Hallforio (CHIEF).Gwiriwch os cafodd eich datganiadau" +
-      " eu gwneud drwy ddefnyddio CHIEF a chysylltwch â <a class=\"govuk-link\" href=\"mailto:pvaenquiries@hmrc.gov.uk\">" +
-      "pvaenquiries@hmrc.gov.uk</a> i wneud cais am ddatganiadau CHIEF</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
-
-    val TestPostponedVATBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd" +
-      " i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
-      "February 2022 to March 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim" +
-      " ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau" +
-      " ’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau yn ystod y dyddiadau" +
-      " y gwnaethoch gais amdanynt.</li><br/>Ni ellir defnyddio’r Gwasanaeth Datganiadau" +
-      " Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio gohiriedig ar gyfer" +
-      " datganiadau a wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a" +
-      " Gaiff eu Mewnforio a’u Hallforio (CHIEF).Gwiriwch os cafodd eich datganiadau" +
-      " eu gwneud drwy ddefnyddio CHIEF a chysylltwch â <a class=\"govuk-link\" href=\"mailto:pvaenquiries@hmrc.gov.uk\">" +
-      "pvaenquiries@hmrc.gov.uk</a> i wneud cais am ddatganiadau CHIEF</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+    def TestPostponedVATBodyCy(companyName: String = defaultCompanyNameCy): String =
+      s"Annwyl $companyName<br/><br/>Ni chafwyd hyd" +
+        " i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
+        "February 2022 to March 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim" +
+        " ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau" +
+        " ’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau yn ystod y dyddiadau" +
+        " y gwnaethoch gais amdanynt.</li><br/>Ni ellir defnyddio’r Gwasanaeth Datganiadau" +
+        " Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio gohiriedig ar gyfer" +
+        " datganiadau a wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a" +
+        " Gaiff eu Mewnforio a’u Hallforio (CHIEF).Gwiriwch os cafodd eich datganiadau" +
+        " eu gwneud drwy ddefnyddio CHIEF a chysylltwch â <a class=\"govuk-link\" href=\"mailto:pvaenquiries@hmrc.gov.uk\">" +
+        "pvaenquiries@hmrc.gov.uk</a> i wneud cais am ddatganiadau CHIEF</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
 
     val encodedDutyDeferementBodyCy: String = "QW5ud3lsIEFwcGxlcyAmIFBlYXJzIEx0ZCA8YnIvPjxici8+TmkgY2hhZnd5ZCBoeW" +
       "QgaeKAmXIgZGF0Z2FuaWFkYXUgZ29oaXJpbyB0b2xsYXUgeSBnd25hZXRob2NoIGdhaXMgYW1kYW55bnQgYXIgZ3lmZXIgbWlzIFNlcHRl" +

--- a/test/domain/secureMessage/BodySpec.scala
+++ b/test/domain/secureMessage/BodySpec.scala
@@ -79,9 +79,34 @@ class BodySpec extends SpecBase {
       PostponedVATBody("Apples & Pears Ltd", dateRange) mustBe TestPostponedVATBody
     }
 
+    "display DutyDefermentBody correctly when company name is empty for English" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
+      DutyDefermentBody(emptyString, dateRange) mustBe TestDutyDefermentBodyForEmptyCompanyName
+    }
+
+    "display C79CertificateBody correctly when company name is empty for English" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
+      C79CertificateBody(emptyString, dateRange) mustBe TestC79CertificateBodyForEmptyCompanyName
+    }
+
+    "display SecurityBody correctly when company name is empty for English" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
+      SecurityBody(emptyString, dateRange) mustBe TestSecurityBodyForEmptyCompanyName
+    }
+
+    "display PostponedVATBody correctly when company name is empty for English" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
+      PostponedVATBody(emptyString, dateRange) mustBe TestPostponedVATBodyForEmptyCompanyName
+    }
+
     "should encode correctly" in new Setup {
       val res = Utils.encodeToUTF8Charsets(TestDutyDefermentBody)
       res mustBe encodedDutyDeferementBody
+    }
+
+    "should encode the body with empty company name correctly for English" in new Setup {
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyForEmptyCompanyName) mustBe
+        encodedDutyDefermentBodyForEmptyCompanyName
     }
 
     "display DutyDeferementBody correctly in welsh" in new Setup {
@@ -104,9 +129,34 @@ class BodySpec extends SpecBase {
       PostponedVATBody("Apples & Pears Ltd", dateRange, welshLangKey) mustBe TestPostponedVATBodyCy
     }
 
+    "display DutyDefermentBody correctly when company name is empty for Welsh" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "September 2022 to October 2022", dateAsNumber = emptyString)
+      DutyDefermentBody(emptyString, dateRange, welshLangKey) mustBe TestDutyDefermentBodyCyWithEmptyCompanyName
+    }
+
+    "display C79CertificateBody correctly when company name is empty for Welsh" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "January 2022 to April 2022", dateAsNumber = emptyString)
+      C79CertificateBody(emptyString, dateRange, welshLangKey) mustBe TestC79CertificateBodyCyWithEmptyCompanyName
+    }
+
+    "display SecurityBody correctly when company name is empty for Welsh" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "March 2021 to May 2021", dateAsNumber = emptyString)
+      SecurityBody(emptyString, dateRange, welshLangKey) mustBe TestSecurityBodyCyWithEmptyCompanyName
+    }
+
+    "display PostponedVATBody correctly when company name is empty for Welsh" in new Setup {
+      override val dateRange: DateRange = DateRange(dateAsText = "February 2022 to March 2022", dateAsNumber = emptyString)
+      PostponedVATBody(emptyString, dateRange, welshLangKey) mustBe TestPostponedVATBodyCyWithEmptyCompanyName
+    }
+
     "should encode correctly in welsh" in new Setup {
       val res = Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCy)
       res mustBe encodedDutyDeferementBodyCy
+    }
+
+    "should encode the body with empty company name correctly for Welsh" in new Setup {
+      Utils.encodeToUTF8Charsets(TestDutyDefermentBodyCyWithEmptyCompanyName) mustBe
+        encodedDutyDeferementBodyCyForEmptyCompanyName
     }
 
     "short text - from the customs" in new Setup {
@@ -253,7 +303,30 @@ class BodySpec extends SpecBase {
       "Duty Deferment Electronic Statements (DDES)</a>.<br/>" +
       "</li></ol>From the Customs Declaration Service"
 
+    val TestDutyDefermentBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
+      "The duty deferment statements you requested for September 2022 to October 2022 were not found." +
+      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>" +
+      "Statements are only created for the periods in which you imported goods." +
+      " Check that you imported goods during the dates you requested.</li><br/>" +
+      "<li>Import VAT certificates for declarations made using Customs Handling " +
+      "of Import and Export Freight (CHIEF) cannot be requested using the Customs " +
+      "Declaration Service. You can get duty deferment statements for declarations" +
+      " made using CHIEF from <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
+      "Duty Deferment Electronic Statements (DDES)</a>.<br/>" +
+      "</li></ol>From the Customs Declaration Service"
+
     val TestC79CertificateBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
+      "The import VAT certificates you requested for January 2022 to April 2022 were not found." +
+      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created " +
+      "for the periods in which you imported goods. Check that you imported goods during" +
+      " the dates you requested.</li><br/><li>Import VAT certificates for declarations made" +
+      " using Customs Handling of Import and Export Freight (CHIEF) cannot be requested using" +
+      " the Customs Declaration Service. Check if your declarations were made using CHIEF and" +
+      " contact <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">" +
+      "cbc-c79requests@hmrc.gov.uk</a> to request CHIEF statements.<br/></li></ol>" +
+      "From the Customs Declaration Service"
+
+    val TestC79CertificateBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
       "The import VAT certificates you requested for January 2022 to April 2022 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created " +
       "for the periods in which you imported goods. Check that you imported goods during" +
@@ -272,7 +345,25 @@ class BodySpec extends SpecBase {
       "of Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service." +
       "<br/></li></ol>From the Customs Declaration Service"
 
+    val TestSecurityBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
+      "The notification of adjustment statements you requested for March 2021 to May 2021 were not found." +
+      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
+      "periods in which you imported goods. Check that you imported goods during the dates you requested." +
+      "</li><br/><li>Notification of adjustment statements for declarations made using Customs Handling " +
+      "of Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service." +
+      "<br/></li></ol>From the Customs Declaration Service"
+
     val TestPostponedVATBody: String = "Dear Apples & Pears Ltd<br/><br/>" +
+      "The postponed import VAT statements you requested for February 2022 to March 2022 were not found." +
+      "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
+      "periods in which you imported goods. Check that you imported goods during the dates you requested." +
+      "</li><br/><li>Postponed import VAT statements for declarations made using Customs Handling of " +
+      "Import and Export Freight (CHIEF) cannot be requested using the Customs Declaration Service. " +
+      "Check if your declarations were made using CHIEF and contact <a class=\"govuk-link\" href=" +
+      "\"mailto:pvaenquiries@hmrc.gov.uk\">pvaenquiries@hmrc.gov.uk</a> to " +
+      "request CHIEF statements.<br/></li></ol>From the Customs Declaration Service"
+
+    val TestPostponedVATBodyForEmptyCompanyName: String = "Dear Customer<br/><br/>" +
       "The postponed import VAT statements you requested for February 2022 to March 2022 were not found." +
       "<br/><br/>There are 2 possible reasons for this:<br/><ol><li>Statements are only created for the " +
       "periods in which you imported goods. Check that you imported goods during the dates you requested." +
@@ -294,7 +385,33 @@ class BodySpec extends SpecBase {
       "EdXR5IERlZmVybWVudCBFbGVjdHJvbmljIFN0YXRlbWVudHMgKERERVMpPC9hPi48YnIvPjwvbGk+PC9vbD5Gcm9tIHRoZSBDdXN0b21" +
       "zIERlY2xhcmF0aW9uIFNlcnZpY2U="
 
+    val encodedDutyDefermentBodyForEmptyCompanyName: String = "RGVhciBDdXN0b21lcjxici8+PGJyLz5UaGUgZHV0eSBkZWZlcm1lbnQ" +
+      "gc3RhdG" +
+      "VtZW50cyB5b3UgcmVxdWVzdGVkIGZvciBTZXB" +
+      "0ZW1iZXIgMjAyMiB0byBPY3RvYmVyIDIwMjIgd2VyZSBub3QgZm91bmQuPGJyLz48YnIvPlRoZXJlIGFyZSAyIHBvc3NpYmxlIHJlYXNvbnM" +
+      "gZm9yIHRoaXM6PGJyLz48b2w+PGxpPlN0YXRlbWVudHMgYXJlIG9ubHkgY3JlYXRlZCBmb3IgdGhlIHBlcmlvZHMgaW4gd2hpY2ggeW91IGl" +
+      "tcG9ydGVkIGdvb2RzLiBDaGVjayB0aGF0IHlvdSBpbXBvcnRlZCBnb29kcyBkdXJpbmcgdGhlIGRhdGVzIHlvdSByZXF1ZXN0ZWQuPC9saT4" +
+      "8YnIvPjxsaT5JbXBvcnQgVkFUIGNlcnRpZmljYXRlcyBmb3IgZGVjbGFyYXRpb25zIG1hZGUgdXNpbmcgQ3VzdG9tcyBIYW5kbGluZyBvZiB" +
+      "JbXBvcnQgYW5kIEV4cG9ydCBGcmVpZ2h0IChDSElFRikgY2Fubm90IGJlIHJlcXVlc3RlZCB1c2luZyB0aGUgQ3VzdG9tcyBEZWNsYXJhdGl" +
+      "vbiBTZXJ2aWNlLiBZb3UgY2FuIGdldCBkdXR5IGRlZmVybWVudCBzdGF0ZW1lbnRzIGZvciBkZWNsYXJhdGlvbnMgbWFkZSB1c2luZyBDSElF" +
+      "RiBmcm9tIDxhIGNsYXNzPSJnb3Z1ay1saW5rIiBocmVmPSJodHRwczovL3NlY3VyZS5obWNlLmdvdi51ay9lY29tL2xvZ2luL2luZGV4Lmh0bW" +
+      "wiPkR1dHkgRGVmZXJtZW50IEVsZWN0cm9uaWMgU3RhdGVtZW50cyAoRERFUyk8L2E+Ljxici8+PC9saT48L29sPkZyb20gdGhlIEN1c3RvbXMg" +
+      "RGVjbGFyYXRpb24gU2VydmljZQ=="
+
     val TestDutyDefermentBodyCy: String = "Annwyl Apples & Pears Ltd <br/><br/>Ni chafwyd hyd i’r" +
+      " datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis September 2022 to October" +
+      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
+      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
+      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
+      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
+      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u" +
+      " Hallforio (CHIEF). Gallwch ddefnyddio’r gwasanaeth" +
+      " <a class=\"govuk-link\" href=\"https://secure.hmce.gov.uk/ecom/login/index.html\">" +
+      " Datganiadau Electronig i Ohirio Tollau (DDES)</a>i gael datganiadau gohirio " +
+      "tollau ar gyfer datganiadau a wnaed gan ddefnyddio’r gwasanaeth CHIEF." +
+      "</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+
+    val TestDutyDefermentBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer <br/><br/>Ni chafwyd hyd i’r" +
       " datganiadau gohirio tollau y gwnaethoch gais amdanynt ar gyfer mis September 2022 to October" +
       " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
       " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
@@ -318,6 +435,17 @@ class BodySpec extends SpecBase {
       " <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">cbc-c79requests@hmrc.gov.uk</a>" +
       " i wneud cais am ddatganiadau CHIEF.</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
 
+    val TestC79CertificateBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd i’r" +
+      " Tystysgrifau TAW mewnforio y gwnaethoch gais amdanynt ar gyfer mis January 2022 to April" +
+      " 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y gwnaethoch" +
+      " fewnforio nwyddau y mae datganiadau’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau" +
+      " yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni ellir defnyddio’r Gwasanaeth" +
+      " Datganiadau Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio ar gyfer datganiadau a" +
+      " wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio" +
+      " (CHIEF).Gwiriwch os cafodd eich datganiadau eu gwneud drwy ddefnyddio CHIEF a chysylltwch â" +
+      " <a class=\"govuk-link\" href=\"mailto:cbc-c79requests@hmrc.gov.uk\">cbc-c79requests@hmrc.gov.uk</a>" +
+      " i wneud cais am ddatganiadau CHIEF.</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+
     val TestSecurityBodyCy: String = "Annwyl Apples & Pears Ltd<br/><br/>Ni chafwyd hyd i’r" +
       " hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer misMarch 2021 to" +
       " May 2021.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y" +
@@ -328,7 +456,29 @@ class BodySpec extends SpecBase {
       " gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio (CHIEF).</li></ol><br/>Oddi" +
       " wrth y Gwasanaeth Datganiadau Tollau"
 
+    val TestSecurityBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd i’r" +
+      " hysbysiad o ddatganiadau addasu y gwnaethoch gais amdanynt ar gyfer misMarch 2021 to" +
+      " May 2021.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim ond ar gyfer y cyfnodau lle y" +
+      " gwnaethoch fewnforio nwyddau y mae datganiadau’n cael eu creu.Gwiriwch eich bod wedi" +
+      " mewnforio nwyddau yn ystod y dyddiadau y gwnaethoch gais amdanynt.</li><br/><li>Ni" +
+      " ellir defnyddio’r Gwasanaeth Datganiadau Tollau (CDS) i wneud cais am hysbysiad o" +
+      " ddatganiadau addasu ar gyfer datganiadau a wnaed gan ddefnyddio system y Tollau ar" +
+      " gyfer Trin Nwyddau a Gaiff eu Mewnforio a’u Hallforio (CHIEF).</li></ol><br/>Oddi" +
+      " wrth y Gwasanaeth Datganiadau Tollau"
+
     val TestPostponedVATBodyCy: String = "Annwyl Apples & Pears Ltd<br/><br/>Ni chafwyd hyd" +
+      " i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
+      "February 2022 to March 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim" +
+      " ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau" +
+      " ’n cael eu creu. Gwiriwch eich bod wedi mewnforio nwyddau yn ystod y dyddiadau" +
+      " y gwnaethoch gais amdanynt.</li><br/>Ni ellir defnyddio’r Gwasanaeth Datganiadau" +
+      " Tollau (CDS) i wneud cais am dystysgrifau TAW mewnforio gohiriedig ar gyfer" +
+      " datganiadau a wnaed gan ddefnyddio system y Tollau ar gyfer Trin Nwyddau a" +
+      " Gaiff eu Mewnforio a’u Hallforio (CHIEF).Gwiriwch os cafodd eich datganiadau" +
+      " eu gwneud drwy ddefnyddio CHIEF a chysylltwch â <a class=\"govuk-link\" href=\"mailto:pvaenquiries@hmrc.gov.uk\">" +
+      "pvaenquiries@hmrc.gov.uk</a> i wneud cais am ddatganiadau CHIEF</li></ol><br/>Oddi wrth y Gwasanaeth Datganiadau Tollau"
+
+    val TestPostponedVATBodyCyWithEmptyCompanyName: String = "Annwyl Gwsmer<br/><br/>Ni chafwyd hyd" +
       " i’r datganiadau TAW mewnforio ohiriedig y gwnaethoch gais amdanynt ar gyfer mis" +
       "February 2022 to March 2022.<br/><br/>Mae dau reswm posibl am hyn:<br/><ol><li>Dim" +
       " ond ar gyfer y cyfnodau lle y gwnaethoch fewnforio nwyddau y mae datganiadau" +
@@ -353,6 +503,20 @@ class BodySpec extends SpecBase {
       "ZWN0cm9uaWcgaSBPaGlyaW8gVG9sbGF1IChEREVTKTwvYT5pIGdhZWwgZGF0Z2FuaWFkYXUgZ29oaXJpbyB0b2xsYXUgYXIgZ3lmZXIgZG" +
       "F0Z2FuaWFkYXUgYSB3bmFlZCBnYW4gZGRlZm55ZGRpb+KAmXIgZ3dhc2FuYWV0aCBDSElFRi48L2xpPjwvb2w+PGJyLz5PZGRpIHdydGgg" +
       "eSBHd2FzYW5hZXRoIERhdGdhbmlhZGF1IFRvbGxhdQ=="
+
+    val encodedDutyDeferementBodyCyForEmptyCompanyName: String = "QW5ud3lsIEd3c21lciA8YnIvPjxici8+TmkgY2hhZnd5ZCBo" +
+      "eWQgaeKAmXIgZGF0Z2FuaWFkYXUgZ29oaXJpbyB0b2xsYXUgeSBnd25hZXRob2NoIGdhaXMgYW1kYW55bnQgYXIgZ3lmZXIgbWlzIFNlcHR" +
+      "lbWJlciAyMDIyIHRvIE9jdG9iZXIgMjAyMi48YnIvPjxici8+TWFlIGRhdSByZXN3bSBwb3NpYmwgYW0gaHluOjxici8+PG9sPjxsaT5EaW" +
+      "0gb25kIGFyIGd5ZmVyIHkgY3lmbm9kYXUgbGxlIHkgZ3duYWV0aG9jaCBmZXduZm9yaW8gbnd5ZGRhdSB5IG1hZSBkYXRnYW5pYWRhdeKAm" +
+      "W4gY2FlbCBldSBjcmV1LiBHd2lyaXdjaCBlaWNoIGJvZCB3ZWRpIG1ld25mb3JpbyBud3lkZGF1IHluIHlzdG9kIHkgZHlkZGlhZGF1IHkg" +
+      "Z3duYWV0aG9jaCBnYWlzIGFtZGFueW50LjwvbGk+PGJyLz48bGk+TmkgZWxsaXIgZGVmbnlkZGlv4oCZciBHd2FzYW5hZXRoIERhdGdhbml" +
+      "hZGF1IFRvbGxhdSAoQ0RTKSBpIHduZXVkIGNhaXMgYW0gZHlzdHlzZ3JpZmF1IFRBVyBtZXduZm9yaW8gYXIgZ3lmZXIgZGF0Z2FuaWFkYX" +
+      "UgYSB3bmFlZCBnYW4gZGRlZm55ZGRpbyBzeXN0ZW0geSBUb2xsYXUgYXIgZ3lmZXIgVHJpbiBOd3lkZGF1IGEgR2FpZmYgZXUgTWV3bmZvcm" +
+      "lvIGHigJl1IEhhbGxmb3JpbyAoQ0hJRUYpLiBHYWxsd2NoIGRkZWZueWRkaW/igJlyIGd3YXNhbmFldGggPGEgY2xhc3M9ImdvdnVrLWxpbm" +
+      "siIGhyZWY9Imh0dHBzOi8vc2VjdXJlLmhtY2UuZ292LnVrL2Vjb20vbG9naW4vaW5kZXguaHRtbCI+IERhdGdhbmlhZGF1IEVsZWN0cm9uaW" +
+      "cgaSBPaGlyaW8gVG9sbGF1IChEREVTKTwvYT5pIGdhZWwgZGF0Z2FuaWFkYXUgZ29oaXJpbyB0b2xsYXUgYXIgZ3lmZXIgZGF0Z2FuaWFkYX" +
+      "UgYSB3bmFlZCBnYW4gZGRlZm55ZGRpb+KAmXIgZ3dhc2FuYWV0aCBDSElFRi48L2xpPjwvb2w+PGJyLz5PZGRpIHdydGggeSBHd2FzYW5hZX" +
+      "RoIERhdGdhbmlhZGF1IFRvbGxhdQ=="
 
     val params: Params = Params(periodStartMonth = "02",
       periodStartYear = "2021",

--- a/test/domain/secureMessage/RequestSpec.scala
+++ b/test/domain/secureMessage/RequestSpec.scala
@@ -56,84 +56,164 @@ class RequestSpec extends SpecBase {
   "getContents" should {
     "return DutyDefermentStatement for English language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "DutyDefermentStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content.head.subject mustBe s"${dutyStatement}${subjectDate}"
+      expectedRequest.content.head.subject mustBe s"$dutyStatement$subjectDate"
       expectedRequest.content.head.body mustBe
         encodeToUTF8Charsets(DutyDefermentBody("Company Name", dateRange))
     }
 
+    "return DutyDefermentStatement for English language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "DutyDefermentStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content.head.subject mustBe s"$dutyStatement$subjectDate"
+      expectedRequest.content.head.body mustBe
+        encodeToUTF8Charsets(DutyDefermentBody(emptyString, dateRange))
+    }
+
     "return C79Certificate for English language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "C79Certificate", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content.head.subject mustBe s"${c79cert}${subjectDate}"
+      expectedRequest.content.head.subject mustBe s"$c79cert$subjectDate"
       expectedRequest.content.head.body mustBe
         encodeToUTF8Charsets(C79CertificateBody("Company Name", dateRange))
     }
 
+    "return C79Certificate for English language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "C79Certificate", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content.head.subject mustBe s"$c79cert$subjectDate"
+      expectedRequest.content.head.body mustBe
+        encodeToUTF8Charsets(C79CertificateBody(emptyString, dateRange))
+    }
+
     "return SecurityStatement for English language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "SecurityStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content.head.subject mustBe s"${securityStatement}${subjectDate}"
+      expectedRequest.content.head.subject mustBe s"$securityStatement$subjectDate"
       expectedRequest.content.head.body mustBe
         encodeToUTF8Charsets(SecurityBody("Company Name", dateRange))
     }
 
+    "return SecurityStatement for English language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "SecurityStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content.head.subject mustBe s"$securityStatement$subjectDate"
+      expectedRequest.content.head.body mustBe
+        encodeToUTF8Charsets(SecurityBody(emptyString, dateRange))
+    }
+
     "return PostponedVATStatement for English language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "PostponedVATStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content.head.subject mustBe s"${postPonedVATStatement}${subjectDate}"
+      expectedRequest.content.head.subject mustBe s"$postPonedVATStatement$subjectDate"
       expectedRequest.content.head.body mustBe
         encodeToUTF8Charsets(PostponedVATBody("Company Name", dateRange))
     }
 
+    "return PostponedVATStatement for English language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "PostponedVATStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content.head.subject mustBe s"$postPonedVATStatement$subjectDate"
+      expectedRequest.content.head.body mustBe
+        encodeToUTF8Charsets(PostponedVATBody(emptyString, dateRange))
+    }
+
     "return DutyDefermentStatement for Welsh language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "DutyDefermentStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content(1).subject mustBe s"${dutyStatementCy}${subjectDateCy}"
+      expectedRequest.content(1).subject mustBe s"$dutyStatementCy$subjectDateCy"
       expectedRequest.content(1).body mustBe encodeToUTF8Charsets(
         DutyDefermentBody("Company Name", dateRangeForWelsh, welshLangKey))
     }
 
+    "return DutyDefermentStatement for Welsh language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "DutyDefermentStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content(1).subject mustBe s"$dutyStatementCy$subjectDateCy"
+      expectedRequest.content(1).body mustBe encodeToUTF8Charsets(
+        DutyDefermentBody(emptyString, dateRangeForWelsh, welshLangKey))
+    }
+
     "return C79Certificate for Welsh language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "C79Certificate", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content(1).subject mustBe s"${c79certCy}${subjectDateCy}"
+      expectedRequest.content(1).subject mustBe s"$c79certCy$subjectDateCy"
       expectedRequest.content(1).body mustBe
         encodeToUTF8Charsets(C79CertificateBody(
           "Company Name", dateRangeForWelsh, welshLangKey))
     }
 
+    "return C79Certificate for Welsh language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "C79Certificate", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content(1).subject mustBe s"$c79certCy$subjectDateCy"
+      expectedRequest.content(1).body mustBe
+        encodeToUTF8Charsets(C79CertificateBody(emptyString, dateRangeForWelsh, welshLangKey))
+    }
+
     "return SecurityStatement for Welsh language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "SecurityStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content(1).subject mustBe s"${securityStatementCy}${subjectDateCy}"
+      expectedRequest.content(1).subject mustBe s"$securityStatementCy$subjectDateCy"
       expectedRequest.content(1).body mustBe
         encodeToUTF8Charsets(SecurityBody("Company Name", dateRangeForWelsh, welshLangKey))
     }
 
+    "return SecurityStatement for Welsh language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "SecurityStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content(1).subject mustBe s"$securityStatementCy$subjectDateCy"
+      expectedRequest.content(1).body mustBe
+        encodeToUTF8Charsets(SecurityBody(emptyString, dateRangeForWelsh, welshLangKey))
+    }
+
     "return PostponedVATStatement for Welsh language" in new Setup {
       override val params: Params = Params("02", "2021", "04", "2021", "PostponedVATStatement", "1234567")
-      val modifiedDoc = histDocRequestSearch.copy(params = params)
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
       val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), "Company Name")
 
-      expectedRequest.content(1).subject mustBe s"${postPonedVATStatementCy}${subjectDateCy}"
+      expectedRequest.content(1).subject mustBe s"$postPonedVATStatementCy$subjectDateCy"
       expectedRequest.content(1).body mustBe
         encodeToUTF8Charsets(PostponedVATBody(
           "Company Name", dateRangeForWelsh, welshLangKey))
+    }
+
+    "return PostponedVATStatement for Welsh language with empty company name" in new Setup {
+      override val params: Params = Params("02", "2021", "04", "2021", "PostponedVATStatement", "1234567")
+      val modifiedDoc: HistoricDocumentRequestSearch = histDocRequestSearch.copy(params = params)
+      val expectedRequest: Request = Request(modifiedDoc, EmailAddress("Email"), emptyString)
+
+      expectedRequest.content(1).subject mustBe s"$postPonedVATStatementCy$subjectDateCy"
+      expectedRequest.content(1).body mustBe
+        encodeToUTF8Charsets(PostponedVATBody(emptyString, dateRangeForWelsh, welshLangKey))
     }
 
     "return eng and cy in list" in new Setup {
@@ -241,7 +321,7 @@ trait Setup {
       params,
       searchRequests)
 
-  def requestJsValue =
+  def requestJsValue: String =
     s"""{
        |  "externalRef": {
        |    "id": "abcd12345",


### PR DESCRIPTION
Description - Code changes to populate default company name in secure message when company name is not returned from the backend

Below has been done as part of this PR

- Add tests and relevant code changes
- Minor refactoring