### PR TITLE
[MMCA-4430]  - Manage your account authorities - display available GB authorities if XI account is not available at backend(SPS/ACC29)

### DIFF
--- a/app/controllers/AccountAuthoritiesController.scala
+++ b/app/controllers/AccountAuthoritiesController.scala
@@ -73,6 +73,10 @@ class AccountAuthoritiesController @Inject()(service: AccountAuthorityService,
     }
   }
 
+  /**
+   * Looks for the mentioned strings in the exception message
+   * This is only being used for the scenario where accounts are not found at backend
+   */
   private def checkBadRequestErrorCodeAndNoAccountsMsg(exceptionMsg: String): Boolean =
     exceptionMsg.contains("returned 400") &&
       exceptionMsg.contains("could not find accounts related to eori")

--- a/app/controllers/AccountAuthoritiesController.scala
+++ b/app/controllers/AccountAuthoritiesController.scala
@@ -26,7 +26,6 @@ import services.AccountAuthorityService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.Inject
-import scala.collection.Seq
 import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
@@ -45,6 +44,11 @@ class AccountAuthoritiesController @Inject()(service: AccountAuthorityService,
         case ex if ex.getMessage.contains("JSON validation") =>
           log.error(s"getAccountAuthorities failed: ${ex.getMessage}")
           InternalServerError("JSON Validation Error")
+
+        case ex if checkBadRequestErrorCodeAndNoAccountsMsg(ex.getMessage) =>
+          log.error(s"Bad Request as no accounts found related to ${eori.value}")
+          Ok(Json.toJson(Seq.empty[AccountWithAuthorities]))
+
         case NonFatal(error) =>
           log.error(s"getAccountAuthorities failed: ${error.getMessage}")
           ServiceUnavailable
@@ -69,4 +73,7 @@ class AccountAuthoritiesController @Inject()(service: AccountAuthorityService,
     }
   }
 
+  private def checkBadRequestErrorCodeAndNoAccountsMsg(exceptionMsg: String): Boolean =
+    exceptionMsg.contains("returned 400") &&
+      exceptionMsg.contains("could not find accounts related to eori")
 }

--- a/test/controllers/AccountAuthoritiesControllerSpec.scala
+++ b/test/controllers/AccountAuthoritiesControllerSpec.scala
@@ -87,7 +87,7 @@ class AccountAuthoritiesControllerSpec extends SpecBase {
       }
     }
 
-    "return 200 (OK)" when {
+    "return 200 (OK) and return empty AccountWithAuthorities" when {
       "get account authorities call fails with BAD_REQUEST and contains " +
         "could not find accounts related to eori message in SourceFaultDetail" in new Setup {
 


### PR DESCRIPTION
Description - Code changes to handle BadRequest scenario where the ErrorResponse contains the "could not find accounts related to eori" message

Below has been done as part of this PR

- Add tests and relevant code changes
- Minor refactoring