### PR TITLE
[MMCA-4438] - Refactor ACC29 error response solution when no XI EORI accounts are available in SPS

### DIFF
--- a/app/controllers/AccountAuthoritiesController.scala
+++ b/app/controllers/AccountAuthoritiesController.scala
@@ -49,7 +49,7 @@ class AccountAuthoritiesController @Inject()(service: AccountAuthorityService,
             log.error(s"getAccountAuthorities failed: $msg")
             InternalServerError("JSON Validation Error")
 
-          case UpstreamErrorResponse(msg, BAD_REQUEST, _, _) if noAccountsMsg(msg) =>
+          case UpstreamErrorResponse(msg, BAD_REQUEST, _, _) if hasNoAccountsForEoriMsg(msg) =>
             log.error(s"Bad Request as no accounts found related to ${eori.value}")
             Ok(Json.toJson(Seq.empty[AccountWithAuthorities]))
 
@@ -81,6 +81,6 @@ class AccountAuthoritiesController @Inject()(service: AccountAuthorityService,
     }
   }
 
-  private def noAccountsMsg(exceptionMsg: String): Boolean =
+  private def hasNoAccountsForEoriMsg(exceptionMsg: String): Boolean =
     exceptionMsg.contains("could not find accounts related to eori")
 }


### PR DESCRIPTION
Description - Code refactor to make use of UpstreamErrorResponse, match on http status code and then message

Below has been covered as part of this PR

- code changes
- minor refactoring