### PR TITLE
[MMCA - 4897] - Explicit audit event for cash account service ACC44 and ACC45 calls

### DIFF
--- a/app/services/AuditingService.scala
+++ b/app/services/AuditingService.scala
@@ -170,6 +170,8 @@ class AuditingService @Inject()(appConfig: AppConfig,
 
   def auditCashAccountTransactionsSearch(cashAccountTransSearchRequest: CashAccountTransactionSearchRequestDetails)
                                         (implicit hc: HeaderCarrier): Future[AuditResult] = {
+    log.info("audit event for ACC44 api call")
+
     val auditJson = Json.toJson(cashAccountTransSearchRequest)
 
     audit(
@@ -182,6 +184,8 @@ class AuditingService @Inject()(appConfig: AppConfig,
 
   def auditCashAccountStatementsRequest(cashAccountStatementRequest: CashAccountStatementRequestDetail)
                                        (implicit hc: HeaderCarrier): Future[AuditResult] = {
+    log.info("audit event for ACC45 api call")
+
     val auditJson = Json.toJson(cashAccountStatementRequest)
 
     audit(

--- a/app/services/AuditingService.scala
+++ b/app/services/AuditingService.scala
@@ -19,9 +19,9 @@ package services
 import config.AppConfig
 import domain._
 import domain.acc40.ResponseDetail
-import models.requests.HistoricDocumentRequest
+import models.requests.{CashAccountStatementRequestDetail, CashAccountTransactionSearchRequestDetails, HistoricDocumentRequest}
 import models.requests.manageAuthorities._
-import models.{AccountNumber, AccountType, EORI, FileRole, FileType}
+import models._
 import play.api.http.HeaderNames
 import play.api.libs.json.{JsValue, Json}
 import play.api.{Logger, LoggerLike}
@@ -54,6 +54,8 @@ class AuditingService @Inject()(appConfig: AppConfig,
   private val REQUEST_AUTHORITIES_TYPE = "RequestAuthorities"
   private val DISPLAY_STANDING_AUTHORITIES_NAME = "Display Authorities CSV"
   private val DISPLAY_STANDING_AUTHORITIES_TYPE = "DisplayStandingAuthoritiesCSV"
+  private val CASH_ACCOUNT_TRANSACTIONS_SEARCH_TRANSACTION_NAME = "Search cash account transactions"
+  private val CASH_ACCOUNT_TRANSACTIONS_SEARCH_AUDIT_TYPE = "SearchCashAccountTransactions"
 
   private val referrer: HeaderCarrier => String = _.headers(Seq(HeaderNames.REFERER)).headOption.fold(hyphen)(_._2)
 
@@ -164,6 +166,30 @@ class AuditingService @Inject()(appConfig: AppConfig,
       "%02d".format(historicDocumentRequest.periodEndMonth)))
 
     audit(AuditModel(HISTORIC_STATEMENT_REQUEST_TRANSACTION_NAME, auditJson, HISTORIC_STATEMENT_REQUEST_AUDIT_TYPE))
+  }
+
+  def auditCashAccountTransactionsSearch(cashAccountTransSearchRequest: CashAccountTransactionSearchRequestDetails)
+                                        (implicit hc: HeaderCarrier): Future[AuditResult] = {
+    val auditJson = Json.toJson(cashAccountTransSearchRequest)
+
+    audit(
+      AuditModel(
+        CASH_ACCOUNT_TRANSACTIONS_SEARCH_TRANSACTION_NAME,
+        auditJson,
+        CASH_ACCOUNT_TRANSACTIONS_SEARCH_AUDIT_TYPE)
+    )
+  }
+
+  def auditCashAccountStatementsRequestACC45(cashAccountStatementRequest: CashAccountStatementRequestDetail)
+                                            (implicit hc: HeaderCarrier): Future[AuditResult] = {
+    val auditJson = Json.toJson(cashAccountStatementRequest)
+
+    audit(
+      AuditModel(
+        CASH_ACCOUNT_TRANSACTIONS_SEARCH_TRANSACTION_NAME,
+        auditJson,
+        CASH_ACCOUNT_TRANSACTIONS_SEARCH_AUDIT_TYPE)
+    )
   }
 
   private def audit(auditModel: AuditModel)(implicit hc: HeaderCarrier): Future[AuditResult] = {

--- a/app/services/AuditingService.scala
+++ b/app/services/AuditingService.scala
@@ -180,8 +180,8 @@ class AuditingService @Inject()(appConfig: AppConfig,
     )
   }
 
-  def auditCashAccountStatementsRequestACC45(cashAccountStatementRequest: CashAccountStatementRequestDetail)
-                                            (implicit hc: HeaderCarrier): Future[AuditResult] = {
+  def auditCashAccountStatementsRequest(cashAccountStatementRequest: CashAccountStatementRequestDetail)
+                                       (implicit hc: HeaderCarrier): Future[AuditResult] = {
     val auditJson = Json.toJson(cashAccountStatementRequest)
 
     audit(

--- a/app/services/AuditingService.scala
+++ b/app/services/AuditingService.scala
@@ -19,9 +19,13 @@ package services
 import config.AppConfig
 import domain._
 import domain.acc40.ResponseDetail
-import models.requests.{CashAccountStatementRequestDetail, CashAccountTransactionSearchRequestDetails, HistoricDocumentRequest}
+import models.requests.{
+  CashAccountStatementRequestDetail,
+  CashAccountTransactionSearchRequestDetails,
+  HistoricDocumentRequest
+}
 import models.requests.manageAuthorities._
-import models._
+import models.{AccountNumber, AccountType, EORI, FileRole, FileType}
 import play.api.http.HeaderNames
 import play.api.libs.json.{JsValue, Json}
 import play.api.{Logger, LoggerLike}

--- a/app/services/CashTransactionsService.scala
+++ b/app/services/CashTransactionsService.scala
@@ -71,8 +71,8 @@ class CashTransactionsService @Inject()(acc31Connector: Acc31Connector,
     }
   }
 
-  def submitCashAccountStatementRequest(request: CashAccountStatementRequestDetail): Future[Either[ErrorDetail,
-    Acc45ResponseCommon]] = {
+  def submitCashAccountStatementRequest(request: CashAccountStatementRequestDetail
+                                       ): Future[Either[ErrorDetail, Acc45ResponseCommon]] = {
     acc45Connector.submitStatementRequest(request)
   }
 

--- a/app/services/CashTransactionsService.scala
+++ b/app/services/CashTransactionsService.scala
@@ -24,6 +24,7 @@ import models.requests.CashAccountTransactionSearchRequestDetails
 import models.responses.ErrorSource.backEnd
 import models.responses.EtmpErrorCode.INVALID_CASH_ACCOUNT_STATUS_TEXT
 import models.responses._
+import uk.gov.hmrc.http.HeaderCarrier
 import utils.Utils.hyphen
 
 import java.time.LocalDate
@@ -33,7 +34,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class CashTransactionsService @Inject()(acc31Connector: Acc31Connector,
                                         acc44Connector: Acc44Connector,
                                         acc45Connector: Acc45Connector,
-                                        domainService: DomainService)(implicit executionContext: ExecutionContext) {
+                                        domainService: DomainService,
+                                        auditingService: AuditingService)(implicit executionContext: ExecutionContext) {
   def retrieveCashTransactionsSummary(can: String,
                                       from: LocalDate,
                                       to: LocalDate): Future[Either[ErrorResponse, CashTransactions]] = {
@@ -62,8 +64,11 @@ class CashTransactionsService @Inject()(acc31Connector: Acc31Connector,
     }
   }
 
-  def retrieveCashAccountTransactions(request: CashAccountTransactionSearchRequestDetails): Future[Either[ErrorDetail,
+  def retrieveCashAccountTransactions(request: CashAccountTransactionSearchRequestDetails)
+                                     (implicit hc: HeaderCarrier): Future[Either[ErrorDetail,
     CashAccountTransactionSearchResponseDetail]] = {
+
+    auditingService.auditCashAccountTransactionsSearch(request)
 
     acc44Connector.cashAccountTransactionSearch(request).map {
       case Right(resValue) => populateSuccessfulResponseDetail(resValue)
@@ -71,8 +76,10 @@ class CashTransactionsService @Inject()(acc31Connector: Acc31Connector,
     }
   }
 
-  def submitCashAccountStatementRequest(request: CashAccountStatementRequestDetail
-                                       ): Future[Either[ErrorDetail, Acc45ResponseCommon]] = {
+  def submitCashAccountStatementRequest(request: CashAccountStatementRequestDetail)
+                                       (implicit hc: HeaderCarrier): Future[Either[ErrorDetail, Acc45ResponseCommon]] = {
+    auditingService.auditCashAccountStatementsRequest(request)
+
     acc45Connector.submitStatementRequest(request)
   }
 

--- a/test/controllers/CashTransactionsControllerSpec.scala
+++ b/test/controllers/CashTransactionsControllerSpec.scala
@@ -36,6 +36,7 @@ import utils.SpecBase
 import utils.TestData.{DAY_1, MONTH_1, MONTH_6, YEAR_2020}
 import models.requests.CashAccountStatementRequestDetail
 import models.responses.{Acc45ResponseCommon, ErrorDetail}
+import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}
@@ -411,6 +412,7 @@ class CashTransactionsControllerSpec extends SpecBase {
     val tenThousand = "10000.00"
 
     implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+    implicit val hc: HeaderCarrier = HeaderCarrier()
 
     val mockAuthConnector: CustomAuthConnector = mock[CustomAuthConnector]
     val mockCashTransactionsService: CashTransactionsService = mock[CashTransactionsService]

--- a/test/controllers/CashTransactionsControllerSpec.scala
+++ b/test/controllers/CashTransactionsControllerSpec.scala
@@ -36,6 +36,7 @@ import utils.SpecBase
 import utils.TestData.{DAY_1, MONTH_1, MONTH_6, YEAR_2020}
 import models.requests.CashAccountStatementRequestDetail
 import models.responses.{Acc45ResponseCommon, ErrorDetail}
+import org.mockito.ArgumentMatchers
 import uk.gov.hmrc.http.HeaderCarrier
 
 import java.time.LocalDate
@@ -189,7 +190,7 @@ class CashTransactionsControllerSpec extends SpecBase {
   "retrieveCashAccountTransactions" should {
 
     "return CashAccountTransactionSearchResponseDetail for the successful response" in new Setup {
-      when(mockCashTransactionsService.retrieveCashAccountTransactions(any))
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(Future.successful(Right(cashAccountTransactionSearchResponseDetailOb)))
 
       running(app) {
@@ -201,7 +202,7 @@ class CashTransactionsControllerSpec extends SpecBase {
     }
 
     "return error response for 400 error code" in new Setup {
-      when(mockCashTransactionsService.retrieveCashAccountTransactions(any))
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(Future.successful(Left(errorDetails)))
 
       running(app) {
@@ -213,7 +214,7 @@ class CashTransactionsControllerSpec extends SpecBase {
     }
 
     "return error response for 500 error code" in new Setup {
-      when(mockCashTransactionsService.retrieveCashAccountTransactions(any))
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(
           Future.successful(
             Left(errorDetails.copy(errorCode = code500, errorMessage = "Error connecting to the server"))))
@@ -228,7 +229,7 @@ class CashTransactionsControllerSpec extends SpecBase {
     }
 
     "return error response for ETMP error codes" in new Setup {
-      when(mockCashTransactionsService.retrieveCashAccountTransactions(any))
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(
           Future.successful(
             Left(errorDetails.copy(
@@ -244,7 +245,7 @@ class CashTransactionsControllerSpec extends SpecBase {
     }
 
     "return error response for 503 error code" in new Setup {
-      when(mockCashTransactionsService.retrieveCashAccountTransactions(any))
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(
           Future.successful(
             Left(errorDetails.copy(
@@ -273,7 +274,7 @@ class CashTransactionsControllerSpec extends SpecBase {
 
       val response: Acc45ResponseCommon = Json.fromJson[Acc45ResponseCommon](Json.parse(acc45ResStr)).get
 
-      when(mockCashTransactionsService.submitCashAccountStatementRequest(cashAccSttRequest))
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
         .thenReturn(Future.successful(Right(response)))
 
       running(app) {
@@ -302,7 +303,7 @@ class CashTransactionsControllerSpec extends SpecBase {
 
       val response: Acc45ResponseCommon = Json.fromJson[Acc45ResponseCommon](Json.parse(acc45ResStr)).get
 
-      when(mockCashTransactionsService.submitCashAccountStatementRequest(cashAccSttRequest))
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
         .thenReturn(Future.successful(Right(response)))
 
       running(app) {
@@ -332,7 +333,7 @@ class CashTransactionsControllerSpec extends SpecBase {
 
       val response: ErrorDetail = Json.fromJson[ErrorDetail](Json.parse(acc45ResStr)).get
 
-      when(mockCashTransactionsService.submitCashAccountStatementRequest(cashAccSttRequest))
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
         .thenReturn(Future.successful(Left(response)))
 
       running(app) {
@@ -362,7 +363,7 @@ class CashTransactionsControllerSpec extends SpecBase {
 
       val response: ErrorDetail = Json.fromJson[ErrorDetail](Json.parse(acc45ResStr)).get
 
-      when(mockCashTransactionsService.submitCashAccountStatementRequest(cashAccSttRequest))
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
         .thenReturn(Future.successful(Left(response)))
 
       running(app) {
@@ -392,7 +393,7 @@ class CashTransactionsControllerSpec extends SpecBase {
 
       val response: ErrorDetail = Json.fromJson[ErrorDetail](Json.parse(acc45ResStr)).get
 
-      when(mockCashTransactionsService.submitCashAccountStatementRequest(cashAccSttRequest))
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
         .thenReturn(Future.successful(Left(response)))
 
       running(app) {

--- a/test/services/AuditingServiceSpec.scala
+++ b/test/services/AuditingServiceSpec.scala
@@ -18,9 +18,12 @@ package services
 
 import domain.{Notification, StandingAuthority, acc41}
 import models._
+import models.requests.{
+  CashAccountPaymentDetails, CashAccountStatementRequestDetail,
+  CashAccountTransactionSearchRequestDetails, DeclarationDetails, HistoricDocumentRequest, SearchType
+}
 import models.requests.ParamName.UCR
 import models.requests.manageAuthorities._
-import models.requests._
 import org.mockito.ArgumentCaptor
 import org.scalatest.matchers.should.Matchers._
 import play.api._

--- a/test/services/AuditingServiceSpec.scala
+++ b/test/services/AuditingServiceSpec.scala
@@ -416,6 +416,14 @@ class AuditingServiceSpec extends SpecBase {
         result.tags.get("transactionName") mustBe Some("Request Authorities CSV")
       }
     }
+
+    "audit the ACC44 Record cash account transactions search request (eventId EXPA021)" in new Setup {
+
+    }
+
+    "audit the ACC45 Record cash account statements request (eventId EXPA022)" in new Setup {
+
+    }
   }
 
   trait Setup {

--- a/test/services/AuditingServiceSpec.scala
+++ b/test/services/AuditingServiceSpec.scala
@@ -464,7 +464,7 @@ class AuditingServiceSpec extends SpecBase {
         when(mockAuditConnector.sendExtendedEvent(extendedDataEventCaptor.capture())(any, any))
           .thenReturn(Future.successful(AuditResult.Success))
 
-        service.auditCashAccountStatementsRequestACC45(cashAccStatementReqDetail)
+        service.auditCashAccountStatementsRequest(cashAccStatementReqDetail)
 
         val result = extendedDataEventCaptor.getValue
 

--- a/test/services/CashTransactionsServiceSpec.scala
+++ b/test/services/CashTransactionsServiceSpec.scala
@@ -28,7 +28,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
-import utils.TestData._
+import utils.TestData.{AMOUNT, BANK_ACCOUNT, CAN, DATE_STRING, EORI_DATA_NAME, PAYMENT_REFERENCE, SORT_CODE}
 
 import java.time.LocalDate
 import scala.concurrent._
@@ -263,7 +263,7 @@ class CashTransactionsServiceSpec extends SpecBase {
       when(mockAcc44Connector.cashAccountTransactionSearch(cashAccTransactionSearchRequestDetails))
         .thenReturn(Future.successful(Right(cashAccTranSearchResponseContainerOb)))
 
-      when(mockAuditingService.)
+      //when(mockAuditingService.)
 
       running(app) {
         val result = service.retrieveCashAccountTransactions(cashAccTransactionSearchRequestDetails)

--- a/test/services/CashTransactionsServiceSpec.scala
+++ b/test/services/CashTransactionsServiceSpec.scala
@@ -19,7 +19,10 @@ package services
 import connectors.{Acc31Connector, Acc44Connector, Acc45Connector}
 import domain.{Declaration, TaxGroup, _}
 import models._
-import models.requests.{CashAccountPaymentDetails, CashAccountStatementRequestDetail, CashAccountTransactionSearchRequestDetails, SearchType}
+import models.requests.{
+  CashAccountPaymentDetails, CashAccountStatementRequestDetail,
+  CashAccountTransactionSearchRequestDetails, SearchType
+}
 import models.responses.PaymentType.Payment
 import models.responses._
 import play.api._
@@ -29,7 +32,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import utils.SpecBase
-import utils.TestData._
+import utils.TestData.{AMOUNT, BANK_ACCOUNT, CAN, DATE_STRING, EORI_DATA_NAME, PAYMENT_REFERENCE, SORT_CODE}
 
 import java.time.LocalDate
 import scala.concurrent._

--- a/test/services/CashTransactionsServiceSpec.scala
+++ b/test/services/CashTransactionsServiceSpec.scala
@@ -19,10 +19,7 @@ package services
 import connectors.{Acc31Connector, Acc44Connector, Acc45Connector}
 import domain.{Declaration, TaxGroup, _}
 import models._
-import models.requests.{
-  CashAccountPaymentDetails, CashAccountStatementRequestDetail,
-  CashAccountTransactionSearchRequestDetails, SearchType
-}
+import models.requests.{CashAccountPaymentDetails, CashAccountStatementRequestDetail, CashAccountTransactionSearchRequestDetails, SearchType}
 import models.responses.PaymentType.Payment
 import models.responses._
 import play.api._
@@ -31,7 +28,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
-import utils.TestData.{AMOUNT, BANK_ACCOUNT, CAN, DATE_STRING, EORI_DATA_NAME, PAYMENT_REFERENCE, SORT_CODE}
+import utils.TestData._
 
 import java.time.LocalDate
 import scala.concurrent._
@@ -266,6 +263,8 @@ class CashTransactionsServiceSpec extends SpecBase {
       when(mockAcc44Connector.cashAccountTransactionSearch(cashAccTransactionSearchRequestDetails))
         .thenReturn(Future.successful(Right(cashAccTranSearchResponseContainerOb)))
 
+      when(mockAuditingService.)
+
       running(app) {
         val result = service.retrieveCashAccountTransactions(cashAccTransactionSearchRequestDetails)
 
@@ -407,6 +406,7 @@ class CashTransactionsServiceSpec extends SpecBase {
     val mockAcc31Connector: Acc31Connector = mock[Acc31Connector]
     val mockAcc44Connector: Acc44Connector = mock[Acc44Connector]
     val mockAcc45Connector: Acc45Connector = mock[Acc45Connector]
+    val mockAuditingService: AuditingService = mock[AuditingService]
 
     val cashAccSttReqDetail: CashAccountStatementRequestDetail = CashAccountStatementRequestDetail(
       "GB123456789012345", "12345678910", "2024-05-10", "2024-05-20")

--- a/test/services/CashTransactionsServiceSpec.scala
+++ b/test/services/CashTransactionsServiceSpec.scala
@@ -27,8 +27,9 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import utils.SpecBase
-import utils.TestData.{AMOUNT, BANK_ACCOUNT, CAN, DATE_STRING, EORI_DATA_NAME, PAYMENT_REFERENCE, SORT_CODE}
+import utils.TestData._
 
 import java.time.LocalDate
 import scala.concurrent._
@@ -263,7 +264,8 @@ class CashTransactionsServiceSpec extends SpecBase {
       when(mockAcc44Connector.cashAccountTransactionSearch(cashAccTransactionSearchRequestDetails))
         .thenReturn(Future.successful(Right(cashAccTranSearchResponseContainerOb)))
 
-      //when(mockAuditingService.)
+      when(mockAuditingService.auditCashAccountTransactionsSearch(any)(any))
+        .thenReturn(Future.successful(AuditResult.Success))
 
       running(app) {
         val result = service.retrieveCashAccountTransactions(cashAccTransactionSearchRequestDetails)
@@ -286,6 +288,9 @@ class CashTransactionsServiceSpec extends SpecBase {
                   responseDetail = None,
                   responseCommon = resCommonOb.copy(statusText = Some("001-Invalid Cash Account"))))
             )))
+
+      when(mockAuditingService.auditCashAccountTransactionsSearch(any)(any))
+        .thenReturn(Future.successful(AuditResult.Success))
 
       running(app) {
         val result = service.retrieveCashAccountTransactions(cashAccTransactionSearchRequestDetails)
@@ -331,6 +336,9 @@ class CashTransactionsServiceSpec extends SpecBase {
         Future.successful(Left(casErrorResponseDetails01))
       )
 
+      when(mockAuditingService.auditCashAccountStatementsRequest(any)(any))
+        .thenReturn(Future.successful(AuditResult.Success))
+
       running(app) {
         val result = await(service.submitCashAccountStatementRequest(cashAccSttReqDetail))
         result mustBe Left(casErrorResponseDetails01)
@@ -352,6 +360,9 @@ class CashTransactionsServiceSpec extends SpecBase {
       when(mockAcc45Connector.submitStatementRequest(cashAccSttReqDetail)).thenReturn(
         Future.successful(Right(casResponseCommon01))
       )
+
+      when(mockAuditingService.auditCashAccountStatementsRequest(any)(any))
+        .thenReturn(Future.successful(AuditResult.Success))
 
       running(app) {
         val result = await(service.submitCashAccountStatementRequest(cashAccSttReqDetail))
@@ -381,6 +392,9 @@ class CashTransactionsServiceSpec extends SpecBase {
       when(mockAcc45Connector.submitStatementRequest(cashAccSttReqDetail)).thenReturn(
         Future.successful(Right(casResponseCommon01))
       )
+
+      when(mockAuditingService.auditCashAccountStatementsRequest(any)(any))
+        .thenReturn(Future.successful(AuditResult.Success))
 
       running(app) {
         val result = await(service.submitCashAccountStatementRequest(cashAccSttReqDetail))
@@ -524,7 +538,8 @@ class CashTransactionsServiceSpec extends SpecBase {
     val app: Application = GuiceApplicationBuilder().overrides(
       inject.bind[Acc31Connector].toInstance(mockAcc31Connector),
       inject.bind[Acc44Connector].toInstance(mockAcc44Connector),
-      inject.bind[Acc45Connector].toInstance(mockAcc45Connector)
+      inject.bind[Acc45Connector].toInstance(mockAcc45Connector),
+      inject.bind[AuditingService].toInstance(mockAuditingService)
     ).configure(
       "microservice.metrics.enabled" -> false,
       "metrics.enabled" -> false,


### PR DESCRIPTION
Description - Code changes to add Audit events to capture the ACC44 (eventId - EXPA021) and ACC45 (eventId - EXPA022) calls

Below has been done as part of this PR

- [x] Add tests and code to add Audit events
- [x] update existing tests
- [x] minor refactoring