### PR TITLE
[MMCA-5157] Check urls for http methods in connectors’ spec using WireMock

### DIFF
--- a/app/models/responses/StandingAuthoritiesResponse.scala
+++ b/app/models/responses/StandingAuthoritiesResponse.scala
@@ -18,14 +18,12 @@ package models.responses
 
 import domain.AccountWithAuthorities
 import models.EORI
-import play.api.libs.json.{Json, OWrites, Reads}
+import play.api.libs.json.{Json, OFormat, OWrites, Reads}
 
 case class StandingAuthoritiesResponse(ownerEori: EORI, accounts: Seq[AccountWithAuthorities])
 
 object StandingAuthoritiesResponse {
-  implicit val standingAuthoritiesRequestWrites: OWrites[StandingAuthoritiesResponse] =
-    Json.writes[StandingAuthoritiesResponse]
 
-  implicit val standingAuthoritiesRequestReads: Reads[StandingAuthoritiesResponse] =
-    Json.reads[StandingAuthoritiesResponse]
+  implicit val standingAuthoritiesResponseFormat: OFormat[StandingAuthoritiesResponse] =
+    Json.format[StandingAuthoritiesResponse]
 }

--- a/app/models/responses/StandingAuthoritiesResponse.scala
+++ b/app/models/responses/StandingAuthoritiesResponse.scala
@@ -18,11 +18,14 @@ package models.responses
 
 import domain.AccountWithAuthorities
 import models.EORI
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 
 case class StandingAuthoritiesResponse(ownerEori: EORI, accounts: Seq[AccountWithAuthorities])
 
 object StandingAuthoritiesResponse {
+  implicit val standingAuthoritiesRequestWrites: OWrites[StandingAuthoritiesResponse] =
+    Json.writes[StandingAuthoritiesResponse]
+
   implicit val standingAuthoritiesRequestReads: Reads[StandingAuthoritiesResponse] =
     Json.reads[StandingAuthoritiesResponse]
 }

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -35,7 +35,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.{
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.Future
 import config.MetaConfig.Platform.MDTP
 
 class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -42,7 +42,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
           )
@@ -65,7 +65,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
           )
@@ -88,7 +88,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
           )

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -29,9 +29,7 @@ import utils.TestData.{FILE_ROLE_C79_CERTIFICATE, MONTH_10, YEAR_2019}
 import utils.Utils.emptyString
 import utils.WireMockSupportProvider
 import uk.gov.hmrc.http.HttpReads.Implicits.*
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalTo, getRequestedFor, noContent, ok, post, serverError, urlPathMatching
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, noContent, ok, post, serverError, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
 

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -30,7 +30,7 @@ import utils.Utils.emptyString
 import utils.WireMockSupportProvider
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalTo, equalToJson, getRequestedFor, noContent, ok, post, serverError, urlPathMatching
+  equalTo, getRequestedFor, noContent, ok, post, serverError, urlPathMatching
 }
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -142,8 +142,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
         Some("dan")
       )
 
-    val app: Application = application().configure(config).build()
-
+    val app: Application          = application().configure(config).build()
     val connector: Acc24Connector = app.injector.instanceOf[Acc24Connector]
   }
 }

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.http.HttpReads.Implicits.*
 import com.github.tomakehurst.wiremock.client.WireMock.{
   equalTo, equalToJson, getRequestedFor, noContent, ok, post, serverError, urlPathMatching
 }
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Future
@@ -53,6 +54,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe true
+
+      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
 
     "return false if any other 2xx status code is returned" in new Setup {
@@ -68,6 +71,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe false
+
+      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
 
     "return false if an exception from Acc24 is returned" in new Setup {
@@ -83,6 +88,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe false
+
+      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
   }
 

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -17,18 +17,13 @@
 package connectors
 
 import models.EORI
-import models.requests.{HistoricDocumentRequest, HistoricStatementRequest}
+import models.requests.HistoricDocumentRequest
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
-import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
 import utils.TestData.{FILE_ROLE_C79_CERTIFICATE, MONTH_10, YEAR_2019}
-import utils.Utils.emptyString
 import utils.WireMockSupportProvider
-import uk.gov.hmrc.http.HttpReads.Implicits.*
 import com.github.tomakehurst.wiremock.client.WireMock.{
   equalTo, matchingJsonPath, noContent, ok, post, serverError, urlPathMatching
 }

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -40,8 +40,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(historicStatementEndPointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
@@ -63,8 +63,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(historicStatementEndPointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
@@ -86,8 +86,8 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(historicStatementEndPointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -61,7 +61,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe true
 
-      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
 
     "return false if any other 2xx status code is returned" in new Setup {
@@ -84,7 +84,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe false
 
-      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
 
     "return false if an exception from Acc24 is returned" in new Setup {
@@ -107,7 +107,7 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
       result mustBe false
 
-      verifyEndPointUrlHit(historicStatementEndPointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(historicStatementEndPointUrl, POST)
     }
   }
 

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -29,7 +29,9 @@ import utils.TestData.{FILE_ROLE_C79_CERTIFICATE, MONTH_10, YEAR_2019}
 import utils.Utils.emptyString
 import utils.WireMockSupportProvider
 import uk.gov.hmrc.http.HttpReads.Implicits.*
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, noContent, ok, post, serverError, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalTo, matchingJsonPath, noContent, ok, post, serverError, urlPathMatching
+}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
 
@@ -47,6 +49,12 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.DAN == 'dan')]")
+          )
           .willReturn(noContent)
       )
 
@@ -64,6 +72,12 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.DAN == 'dan')]")
+          )
           .willReturn(ok)
       )
 
@@ -81,6 +95,12 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.statementType == 'C79Certificate')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.HistoricalStatementRetrievalInterfaceMetadata[?(@.DAN == 'dan')]")
+          )
           .willReturn(serverError)
       )
 
@@ -99,9 +119,6 @@ class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
          |  acc24 {
          |            host = $wireMockHost
          |            port = $wireMockPort
-         |            context-base = "/customs-financials-hods-stub"
-         |            bearer-token = "test1234567"
-         |            serviceName="hods-acc24"
          |        }
          |  }
          |}

--- a/test/connectors/Acc24ConnectorSpec.scala
+++ b/test/connectors/Acc24ConnectorSpec.scala
@@ -17,65 +17,97 @@
 package connectors
 
 import models.EORI
-import models.requests.HistoricDocumentRequest
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.Application
+import models.requests.{HistoricDocumentRequest, HistoricStatementRequest}
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HeaderCarrier
 import utils.SpecBase
 import utils.TestData.{FILE_ROLE_C79_CERTIFICATE, MONTH_10, YEAR_2019}
 import utils.Utils.emptyString
+import utils.WireMockSupportProvider
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalTo, equalToJson, getRequestedFor, noContent, ok, post, serverError, urlPathMatching
+}
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Future
+import config.MetaConfig.Platform.MDTP
 
-class Acc24ConnectorSpec extends SpecBase {
+class Acc24ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "sendHistoricDocumentRequest" should {
     "return true when a successful request has been made" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(NO_CONTENT, emptyString)))
 
-      running(app) {
-        val result = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
-        result mustBe true
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(historicStatementEndPointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .willReturn(noContent)
+      )
+
+      val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
+      result mustBe true
     }
 
     "return false if any other 2xx status code is returned" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(OK, emptyString)))
 
-      running(app) {
-        val result = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
-        result mustBe false
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(historicStatementEndPointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .willReturn(ok)
+      )
+
+      val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
+      result mustBe false
     }
 
     "return false if an exception from Acc24 is returned" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        val result = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
-        result mustBe false
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(historicStatementEndPointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .willReturn(serverError)
+      )
+
+      val result: Boolean = await(connector.sendHistoricDocumentRequest(historicDocumentRequest))
+      result mustBe false
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc24 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |            context-base = "/customs-financials-hods-stub"
+         |            bearer-token = "test1234567"
+         |            serviceName="hods-acc24"
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val historicStatementEndPointUrl = "/customs-financials-hods-stub/accounts/cmdghistoricalstatementretrieval/v1"
 
     val historicDocumentRequest: HistoricDocumentRequest =
       HistoricDocumentRequest(
@@ -88,17 +120,7 @@ class Acc24ConnectorSpec extends SpecBase {
         Some("dan")
       )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
+    val app: Application = application().configure(config).build()
 
     val connector: Acc24Connector = app.injector.instanceOf[Acc24Connector]
   }

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -46,7 +46,7 @@ class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: JsObject = await(connector.getAccounts(requestBody))
       result mustBe Json.obj("someOther" -> "value")
 
-      verifyEndPointUrlHit(getAccountsUrl, POST)
+      verifyExactlyOneEndPointUrlHit(getAccountsUrl, POST)
     }
   }
 

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.Future
+
 
 class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -17,8 +17,6 @@
 package connectors
 
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, getRequestedFor, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, ok, post, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import com.typesafe.config.ConfigFactory

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -38,7 +38,7 @@ class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(equalToJson(requestBody.toString))
           .willReturn(ok(Json.obj("someOther" -> "value").toString))
       )

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -16,52 +16,67 @@
 
 package connectors
 
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, getRequestedFor, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import config.MetaConfig.Platform.MDTP
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.Future
 
-class Acc27ConnectorSpec extends SpecBase {
+class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "getAccounts" should {
     "return a json on a successful response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(Json.obj("someOther" -> "value")))
 
-      running(app) {
-        val result = await(connector.getAccounts(requestBody))
-        result mustBe Json.obj("someOther" -> "value")
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(getAccountsUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .willReturn(ok(Json.obj("someOther" -> "value").toString))
+      )
+
+      val result: JsObject = await(connector.getAccounts(requestBody))
+      result mustBe Json.obj("someOther" -> "value")
+
+      verifyEndPointUrlHit(getAccountsUrl, POST)
     }
   }
 
-  trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
-    val requestBody: JsObject          = Json.obj("some" -> "value")
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc27 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |            context-base = "/customs-financials-hods-stub"
+         |            bearer-token = "test1234567"
+         |            endpoint = "/accounts/getaccountsandbalances/v1"
+         |            serviceName="hods-acc27"
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
+  trait Setup {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val requestBody: JsObject      = Json.obj("some" -> "value")
+
+    val getAccountsUrl = "/customs-financials-hods-stub/accounts/getaccountsandbalances/v1"
+
+    val app: Application = application().configure(config).build()
 
     val connector: Acc27Connector = app.injector.instanceOf[Acc27Connector]
   }

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -26,8 +26,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import com.typesafe.config.ConfigFactory
 
-
-
 class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "getAccounts" should {

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -36,8 +36,8 @@ class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(getAccountsUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(equalToJson(requestBody.toString))
           .willReturn(ok(Json.obj("someOther" -> "value").toString))

--- a/test/connectors/Acc27ConnectorSpec.scala
+++ b/test/connectors/Acc27ConnectorSpec.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, ok, post, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import com.typesafe.config.ConfigFactory
@@ -41,6 +41,7 @@ class Acc27ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(equalToJson(requestBody.toString))
           .willReturn(ok(Json.obj("someOther" -> "value").toString))
       )
 

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -37,7 +37,7 @@ import models.responses.{
 }
 
 import java.time.LocalDate
-import scala.concurrent.Future
+
 
 class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -16,11 +16,8 @@
 
 package connectors
 
-import models.requests.GuaranteeAccountTransactionsRequest
-import models.responses.{
-  GetGGATransactionResponse, GuaranteeTransactionDeclaration, GuaranteeTransactionsResponse, ResponseCommon,
-  ResponseDetail
-}
+import models.requests.{GuaranteeAccountTransactionsRequest, RequestCommon}
+import models.requests.*
 import models.{AccountNumber, ErrorResponse, ExceededThresholdErrorException, NoAssociatedDataException}
 import play.api.{Application, Configuration}
 import play.api.inject.bind
@@ -28,11 +25,16 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
+import config.AppConfig
 import config.MetaConfig.Platform.MDTP
 import play.api.libs.json.Json
+import models.responses.{
+  GetGGATransactionResponse, GuaranteeTransactionDeclaration, GuaranteeTransactionsResponse, ResponseCommon,
+  ResponseDetail
+}
 
 import java.time.LocalDate
 import scala.concurrent.Future
@@ -48,6 +50,13 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramValue == 'CDS')]")
+          )
+          .withRequestBody(matchingJsonPath("$.getGGATransactionListing[?(@.requestDetail.gan == 'GAN')]"))
           .willReturn(ok(Json.toJson(response).toString))
       )
 
@@ -67,6 +76,13 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramValue == 'CDS')]")
+          )
+          .withRequestBody(matchingJsonPath("$.getGGATransactionListing[?(@.requestDetail.gan == 'GAN')]"))
           .willReturn(ok(Json.toJson(noDataResponse).toString))
       )
 
@@ -86,6 +102,13 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
           .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramValue == 'CDS')]")
+          )
+          .withRequestBody(matchingJsonPath("$.getGGATransactionListing[?(@.requestDetail.gan == 'GAN')]"))
           .willReturn(ok(Json.toJson(tooMuchDataRequestedResponse).toString))
       )
 

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -42,8 +42,8 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(retrieveGuaranteeTransactionsUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
@@ -68,8 +68,8 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(retrieveGuaranteeTransactionsUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
@@ -94,8 +94,8 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(retrieveGuaranteeTransactionsUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -44,7 +44,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
           )
@@ -70,7 +70,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
           )
@@ -96,7 +96,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getGGATransactionListing[?(@.requestCommon.requestParameters.paramName == 'REGIME')]")
           )

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -65,7 +65,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Right(List.empty)
 
-      verifyEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
+      verifyExactlyOneEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
     }
 
     "return NoAssociatedData error response when responded with no associated data" in new Setup {
@@ -91,7 +91,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(NoAssociatedDataException)
 
-      verifyEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
+      verifyExactlyOneEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
     }
 
     "return ExceededThreshold error response when responded with exceeded threshold" in new Setup {
@@ -117,7 +117,7 @@ class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(ExceededThresholdErrorException)
 
-      verifyEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
+      verifyExactlyOneEndPointUrlHit(retrieveGuaranteeTransactionsUrl, POST)
     }
   }
 

--- a/test/connectors/Acc28ConnectorSpec.scala
+++ b/test/connectors/Acc28ConnectorSpec.scala
@@ -16,19 +16,15 @@
 
 package connectors
 
-import models.requests.{GuaranteeAccountTransactionsRequest, RequestCommon}
 import models.requests.*
 import models.{AccountNumber, ErrorResponse, ExceededThresholdErrorException, NoAssociatedDataException}
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.typesafe.config.ConfigFactory
-import config.AppConfig
 import config.MetaConfig.Platform.MDTP
 import play.api.libs.json.Json
 import models.responses.{
@@ -37,7 +33,6 @@ import models.responses.{
 }
 
 import java.time.LocalDate
-
 
 class Acc28ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc29ConnectorSpec.scala
+++ b/test/connectors/Acc29ConnectorSpec.scala
@@ -38,8 +38,8 @@ class Acc29ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(getStandingAuthoritiesUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(matchingJsonPath("$.requestCommon[?(@.regime == 'CDS')]"))
           .withRequestBody(matchingJsonPath("$.requestDetail[?(@.ownerEori == 'testEORI')]"))

--- a/test/connectors/Acc29ConnectorSpec.scala
+++ b/test/connectors/Acc29ConnectorSpec.scala
@@ -56,7 +56,7 @@ class Acc29ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Seq[AccountWithAuthorities] = await(connector.getStandingAuthorities(EORI(EORI_VALUE)))
       result mustBe Seq.empty
 
-      verifyEndPointUrlHit(getStandingAuthoritiesUrl, POST)
+      verifyExactlyOneEndPointUrlHit(getStandingAuthoritiesUrl, POST)
     }
   }
 

--- a/test/connectors/Acc29ConnectorSpec.scala
+++ b/test/connectors/Acc29ConnectorSpec.scala
@@ -35,7 +35,7 @@ import models.requests.manageAuthorities.{
 }
 import utils.TestData.EORI_VALUE
 
-import scala.concurrent.Future
+
 
 class Acc29ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc29ConnectorSpec.scala
+++ b/test/connectors/Acc29ConnectorSpec.scala
@@ -21,8 +21,6 @@ import domain.AccountWithAuthorities
 import models.EORI
 import models.responses.StandingAuthoritiesResponse
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
@@ -30,12 +28,7 @@ import play.api.libs.json.Json
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
 import config.MetaConfig.Platform.MDTP
-import models.requests.manageAuthorities.{
-  AuthoritiesRequestCommon, AuthoritiesRequestDetail, StandingAuthoritiesRequest
-}
 import utils.TestData.EORI_VALUE
-
-
 
 class Acc29ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc29ConnectorSpec.scala
+++ b/test/connectors/Acc29ConnectorSpec.scala
@@ -40,7 +40,7 @@ class Acc29ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(matchingJsonPath("$.requestCommon[?(@.regime == 'CDS')]"))
           .withRequestBody(matchingJsonPath("$.requestDetail[?(@.ownerEori == 'testEORI')]"))
           .willReturn(ok(Json.toJson(response).toString))

--- a/test/connectors/Acc30ConnectorSpec.scala
+++ b/test/connectors/Acc30ConnectorSpec.scala
@@ -21,54 +21,121 @@ import models.requests.manageAuthorities.*
 import models.{AccountNumber, EORI}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
+import com.typesafe.config.ConfigFactory
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
 import utils.Utils.emptyString
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalTo, matchingJsonPath, noContent, ok, post, serverError, urlPathMatching
+}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import utils.TestData.EORI_VALUE
 
 import java.time.LocalDate
 import scala.concurrent.Future
+import config.MetaConfig.Platform.MDTP
 
-class Acc30ConnectorSpec extends SpecBase {
+class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "grantAccountAuthorities" should {
 
     "return true when the api responds with 204" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(NO_CONTENT, emptyString)))
 
-      running(app) {
-        val result = await(connector.grantAccountAuthorities(grantRequest, EORI("someEori")))
-        result mustBe true
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestDetail.ownerEori == 'testEORI')]")
+          )
+          .willReturn(noContent)
+      )
+
+      val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
+      result mustBe true
+
+      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api responds with a successful response that isn't 204" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(OK, emptyString)))
 
-      running(app) {
-        val result = await(connector.grantAccountAuthorities(grantRequest, EORI("someEori")))
-        result mustBe false
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestDetail.ownerEori == 'testEORI')]")
+          )
+          .willReturn(ok(emptyString))
+      )
+
+      val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
+      result mustBe false
+
+      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api fails" in new Setup {
+
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestDetail.ownerEori == 'testEORI')]")
+          )
+          .willReturn(serverError)
+      )
+
+      val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
+      result mustBe false
+
+      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+    }
+
+    "return false when Future is failed with exception" in new Setup {
+      val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        val result = await(connector.grantAccountAuthorities(grantRequest, EORI("someEori")))
+      running(application) {
+        val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
         result mustBe false
       }
     }
@@ -77,46 +144,96 @@ class Acc30ConnectorSpec extends SpecBase {
   "revokeAccountAuthorities" should {
 
     "return true when the api responds with 204" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(NO_CONTENT, emptyString)))
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestDetail.ownerEori == 'testEORI')]")
+          )
+          .willReturn(noContent)
+      )
 
-      running(app) {
-        val result = await(connector.revokeAccountAuthorities(revokeRequest, EORI("someEori")))
-        result mustBe true
-      }
+      val result: Boolean = await(connector.revokeAccountAuthorities(revokeRequest, EORI(EORI_VALUE)))
+      result mustBe true
+
+      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api responds with a successful response that isn't 204" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(OK, emptyString)))
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestDetail.ownerEori == 'testEORI')]")
+          )
+          .willReturn(ok(emptyString))
+      )
 
-      running(app) {
-        val result = await(connector.revokeAccountAuthorities(revokeRequest, EORI("someEori")))
-        result mustBe false
-      }
+      val result: Boolean = await(connector.revokeAccountAuthorities(revokeRequest, EORI(EORI_VALUE)))
+      result mustBe false
+
+      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api fails" in new Setup {
+      val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        val result = await(connector.revokeAccountAuthorities(revokeRequest, EORI("someEori")))
+      running(application) {
+        val result = await(connector.revokeAccountAuthorities(revokeRequest, EORI(EORI_VALUE)))
         result mustBe false
       }
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc30 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val acc30ManageAccountAuthoritiesEndpointUrl = "/customs-financials-hods-stub/accounts/managestandingauthorities/v1"
 
     val grantRequest: GrantAuthorityRequest = GrantAuthorityRequest(
       Accounts(None, Seq.empty, None),
@@ -128,21 +245,11 @@ class Acc30ConnectorSpec extends SpecBase {
     val revokeRequest: RevokeAuthorityRequest = RevokeAuthorityRequest(
       AccountNumber("GAN"),
       CdsCashAccount,
-      EORI("someEori"),
+      EORI(EORI_VALUE),
       AuthorisedUser("someUser", "someRole")
     )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
+    val app: Application = application().configure(config).build()
 
     val connector: Acc30Connector = app.injector.instanceOf[Acc30Connector]
   }

--- a/test/connectors/Acc30ConnectorSpec.scala
+++ b/test/connectors/Acc30ConnectorSpec.scala
@@ -46,7 +46,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -69,7 +69,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -92,7 +92,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -115,7 +115,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -140,7 +140,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -162,7 +162,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )
@@ -185,7 +185,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
           )

--- a/test/connectors/Acc30ConnectorSpec.scala
+++ b/test/connectors/Acc30ConnectorSpec.scala
@@ -27,7 +27,7 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
 import utils.{SpecBase, WireMockSupportProvider}
 import utils.Utils.emptyString
 import com.github.tomakehurst.wiremock.client.WireMock.{

--- a/test/connectors/Acc30ConnectorSpec.scala
+++ b/test/connectors/Acc30ConnectorSpec.scala
@@ -44,8 +44,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -67,8 +67,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -90,8 +90,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -113,8 +113,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -138,8 +138,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -160,8 +160,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
@@ -183,8 +183,8 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc30ManageAccountAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.manageStandingAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")

--- a/test/connectors/Acc30ConnectorSpec.scala
+++ b/test/connectors/Acc30ConnectorSpec.scala
@@ -64,7 +64,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
       result mustBe true
 
-      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api responds with a successful response that isn't 204" in new Setup {
@@ -87,7 +87,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
       result mustBe false
 
-      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api fails" in new Setup {
@@ -110,7 +110,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.grantAccountAuthorities(grantRequest, EORI(EORI_VALUE)))
       result mustBe false
 
-      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when Future is failed with exception" in new Setup {
@@ -162,7 +162,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.revokeAccountAuthorities(revokeRequest, EORI(EORI_VALUE)))
       result mustBe true
 
-      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api responds with a successful response that isn't 204" in new Setup {
@@ -184,7 +184,7 @@ class Acc30ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Boolean = await(connector.revokeAccountAuthorities(revokeRequest, EORI(EORI_VALUE)))
       result mustBe false
 
-      verifyEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc30ManageAccountAuthoritiesEndpointUrl, POST)
     }
 
     "return false when the api fails" in new Setup {

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -44,7 +44,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
               "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
@@ -71,7 +71,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
               "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
@@ -99,7 +99,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
             .withHeader(CONTENT_TYPE, equalTo("application/json"))
             .withHeader(ACCEPT, equalTo("application/json"))
-            .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+            .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath(
                 "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
@@ -126,7 +126,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
               "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
@@ -154,7 +154,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
             .withHeader(CONTENT_TYPE, equalTo("application/json"))
             .withHeader(ACCEPT, equalTo("application/json"))
-            .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+            .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath(
                 "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -42,8 +42,8 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
@@ -69,8 +69,8 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
@@ -97,8 +97,8 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath(
@@ -124,8 +124,8 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath(
@@ -152,8 +152,8 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath(

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -22,8 +22,6 @@ import models.responses.{
 }
 import models.{ErrorResponse, ExceededThresholdErrorException, NoAssociatedDataException}
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
@@ -34,8 +32,6 @@ import com.typesafe.config.ConfigFactory
 import config.MetaConfig.Platform.MDTP
 
 import java.time.LocalDate
-import scala.concurrent.ExecutionContext.Implicits.global
-
 
 class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -65,7 +65,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Right(Some(CashTransactionsResponseDetail(None, None, None)))
 
-      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return NoAssociatedData error response when responded with no associated data" in new Setup {
@@ -92,7 +92,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(NoAssociatedDataException)
 
-      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return NoAssociatedData error response when responded with no associated data " +
@@ -120,7 +120,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(NoAssociatedDataException)
 
-        verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
       }
 
     "return ExceededThreshold error response when responded with exceeded threshold" in new Setup {
@@ -147,7 +147,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(ExceededThresholdErrorException)
 
-      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return ExceededThreshold error response when responded with exceeded threshold " +
@@ -175,7 +175,7 @@ class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(ExceededThresholdErrorException)
 
-        verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
       }
   }
 

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -20,96 +20,188 @@ import models.responses.{
   CashTransactionsResponse, CashTransactionsResponseCommon, CashTransactionsResponseDetail,
   GetCashAccountTransactionListingResponse
 }
-import models.{ExceededThresholdErrorException, NoAssociatedDataException}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.Application
+import models.{ErrorResponse, ExceededThresholdErrorException, NoAssociatedDataException}
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
+import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import com.typesafe.config.ConfigFactory
+import config.MetaConfig.Platform.MDTP
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class Acc31ConnectorSpec extends SpecBase {
+class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "retrieveCashTransactions" should {
 
     "return a list of declarations on a successful response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(response))
 
-      running(app) {
-        val result = await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
-        result mustBe Right(Some(CashTransactionsResponseDetail(None, None, None)))
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath(
+              "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
+            )
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getCashAccountTransactionListingRequest[?(@.requestDetail.CAN == 'can')]")
+          )
+          .willReturn(ok(Json.toJson(response).toString))
+      )
+
+      val result: Either[ErrorResponse, Option[CashTransactionsResponseDetail]] =
+        await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
+
+      result mustBe Right(Some(CashTransactionsResponseDetail(None, None, None)))
+
+      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return NoAssociatedData error response when responded with no associated data" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(noDataResponse))
 
-      running(app) {
-        val result = await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
-        result mustBe Left(NoAssociatedDataException)
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath(
+              "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
+            )
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getCashAccountTransactionListingRequest[?(@.requestDetail.CAN == 'can')]")
+          )
+          .willReturn(ok(Json.toJson(noDataResponse).toString))
+      )
+
+      val result: Either[ErrorResponse, Option[CashTransactionsResponseDetail]] =
+        await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
+
+      result mustBe Left(NoAssociatedDataException)
+
+      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return NoAssociatedData error response when responded with no associated data " +
       "and maxTransactionsExceeded field is set to true" in new Setup {
-        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-        when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-        when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-        when(requestBuilder.execute(any, any)).thenReturn(Future.successful(noDataResponse02))
 
-        running(app) {
-          connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()).map { result =>
-            result mustBe Left(NoAssociatedDataException)
-          }
-        }
+        wireMockServer.stubFor(
+          post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
+            .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+            .withHeader(CONTENT_TYPE, equalTo("application/json"))
+            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+            .withRequestBody(
+              matchingJsonPath(
+                "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
+              )
+            )
+            .withRequestBody(
+              matchingJsonPath("$.getCashAccountTransactionListingRequest[?(@.requestDetail.CAN == 'can')]")
+            )
+            .willReturn(ok(Json.toJson(noDataResponse02).toString))
+        )
+
+        val result: Either[ErrorResponse, Option[CashTransactionsResponseDetail]] =
+          await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
+
+        result mustBe Left(NoAssociatedDataException)
+
+        verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
       }
 
     "return ExceededThreshold error response when responded with exceeded threshold" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(tooMuchDataRequestedResponse))
 
-      running(app) {
-        val result = await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
-        result mustBe Left(ExceededThresholdErrorException)
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath(
+              "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
+            )
+          )
+          .withRequestBody(
+            matchingJsonPath("$.getCashAccountTransactionListingRequest[?(@.requestDetail.CAN == 'can')]")
+          )
+          .willReturn(ok(Json.toJson(tooMuchDataRequestedResponse).toString))
+      )
+
+      val result: Either[ErrorResponse, Option[CashTransactionsResponseDetail]] =
+        await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
+
+      result mustBe Left(ExceededThresholdErrorException)
+
+      verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
     }
 
     "return ExceededThreshold error response when responded with exceeded threshold " +
       "and maxTransactionsExceeded field is set to false" in new Setup {
-        when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-        when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-        when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-        when(requestBuilder.execute(any, any)).thenReturn(Future.successful(tooMuchDataRequestedResponse02))
 
-        running(app) {
-          connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()).map { result =>
-            result mustBe Left(ExceededThresholdErrorException)
-          }
-        }
+        wireMockServer.stubFor(
+          post(urlPathMatching(acc31GetCashAccountTransactionListingEndpointUrl))
+            .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+            .withHeader(CONTENT_TYPE, equalTo("application/json"))
+            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+            .withRequestBody(
+              matchingJsonPath(
+                "$.getCashAccountTransactionListingRequest[?(@.requestCommon.originatingSystem == 'MDTP')]"
+              )
+            )
+            .withRequestBody(
+              matchingJsonPath("$.getCashAccountTransactionListingRequest[?(@.requestDetail.CAN == 'can')]")
+            )
+            .willReturn(ok(Json.toJson(tooMuchDataRequestedResponse02).toString))
+        )
+
+        val result: Either[ErrorResponse, Option[CashTransactionsResponseDetail]] =
+          await(connector.retrieveCashTransactions("can", LocalDate.now(), LocalDate.now()))
+
+        result mustBe Left(ExceededThresholdErrorException)
+
+        verifyEndPointUrlHit(acc31GetCashAccountTransactionListingEndpointUrl, POST)
       }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc31 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
-    val noAssociatedDataMessage        = "025-No associated data found"
-    val exceedsThresholdMessage        = "091-The query has exceeded the threshold, please refine the search"
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val acc31GetCashAccountTransactionListingEndpointUrl =
+      "/customs-financials-hods-stub/accounts/getcashaccounttransactionlisting/v1"
+
+    val noAssociatedDataMessage = "025-No associated data found"
+    val exceedsThresholdMessage = "091-The query has exceeded the threshold, please refine the search"
 
     val response: CashTransactionsResponse = CashTransactionsResponse(
       GetCashAccountTransactionListingResponse(
@@ -146,18 +238,7 @@ class Acc31ConnectorSpec extends SpecBase {
       )
     )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
-
+    val app: Application          = application().configure(config).build()
     val connector: Acc31Connector = app.injector.instanceOf[Acc31Connector]
   }
 }

--- a/test/connectors/Acc31ConnectorSpec.scala
+++ b/test/connectors/Acc31ConnectorSpec.scala
@@ -35,7 +35,7 @@ import config.MetaConfig.Platform.MDTP
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
 
 class Acc31ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -16,44 +16,74 @@
 
 package connectors
 
-import domain.acc37.{AmendCorrespondenceAddressResponse, ContactDetails, ResponseCommon}
+import domain.acc37.{AmendCorrespondenceAddressResponse, ContactDetails, Response, ResponseCommon}
 import models.{AccountNumber, EORI, EmailAddress}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
+import play.api.libs.json.Json
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
+import com.typesafe.config.ConfigFactory
 import utils.TestData.COUNTRY_CODE_GB
 import utils.Utils.emptyString
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import config.MetaConfig.Platform.MDTP
+import utils.TestData.EORI_VALUE
 
 import scala.concurrent.Future
 
-class Acc37ConnectorSpec extends SpecBase {
+class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "updateAccountContactDetails" should {
     "return an acc37 response on a successful api call" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(response))
 
-      running(app) {
-        val result =
-          await(connector.updateAccountContactDetails(AccountNumber("dan"), EORI("someEori"), acc37ContactInfo))
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc37UpdateAccountContactDetailsEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.amendCorrespondenceAddressRequest[?(@.requestCommon.originatingSystem == 'Digital')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.amendCorrespondenceAddressRequest[?(@.requestDetail.eori == 'testEORI')]")
+          )
+          .willReturn(ok(Json.toJson(response).toString))
+      )
 
-        result mustBe response
-      }
+      val result: Response =
+        await(connector.updateAccountContactDetails(AccountNumber("dan"), EORI(EORI_VALUE), acc37ContactInfo))
+
+      result mustBe response
+
+      verifyEndPointUrlHit(acc37UpdateAccountContactDetailsEndpointUrl, POST)
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc37 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val acc37UpdateAccountContactDetailsEndpointUrl =
+      "/customs-financials-hods-stub/accounts/amendcorrespondenceaddress/v1"
 
     val response: domain.acc37.Response = domain.acc37.Response(
       AmendCorrespondenceAddressResponse(
@@ -79,17 +109,7 @@ class Acc37ConnectorSpec extends SpecBase {
       Some(EmailAddress("somedata@email.com"))
     )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
+    val app: Application = application().configure(config).build()
 
     val connector: Acc37Connector = app.injector.instanceOf[Acc37Connector]
   }

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -109,8 +109,7 @@ class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
       Some(EmailAddress("somedata@email.com"))
     )
 
-    val app: Application = application().configure(config).build()
-
+    val app: Application          = application().configure(config).build()
     val connector: Acc37Connector = app.injector.instanceOf[Acc37Connector]
   }
 }

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -39,8 +39,8 @@ class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc37UpdateAccountContactDetailsEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.amendCorrespondenceAddressRequest[?(@.requestCommon.originatingSystem == 'Digital')]")

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -41,7 +41,7 @@ class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.amendCorrespondenceAddressRequest[?(@.requestCommon.originatingSystem == 'Digital')]")
           )

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -33,7 +33,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import utils.TestData.EORI_VALUE
 
-import scala.concurrent.Future
+
 
 class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -60,7 +60,7 @@ class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe response
 
-      verifyEndPointUrlHit(acc37UpdateAccountContactDetailsEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc37UpdateAccountContactDetailsEndpointUrl, POST)
     }
   }
 

--- a/test/connectors/Acc37ConnectorSpec.scala
+++ b/test/connectors/Acc37ConnectorSpec.scala
@@ -19,9 +19,7 @@ package connectors
 import domain.acc37.{AmendCorrespondenceAddressResponse, ContactDetails, Response, ResponseCommon}
 import models.{AccountNumber, EORI, EmailAddress}
 import play.api.{Application, Configuration}
-import play.api.inject.bind
 import play.api.libs.json.Json
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
@@ -32,8 +30,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPat
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import utils.TestData.EORI_VALUE
-
-
 
 class Acc37ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc38ConnectorSpec.scala
+++ b/test/connectors/Acc38ConnectorSpec.scala
@@ -19,8 +19,6 @@ package connectors
 import domain.acc38.{GetCorrespondenceAddressResponse, Response}
 import models.{AccountNumber, EORI}
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
@@ -31,8 +29,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 import utils.TestData.EORI_VALUE
 import utils.Utils.emptyString
-
-
 
 class Acc38ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc38ConnectorSpec.scala
+++ b/test/connectors/Acc38ConnectorSpec.scala
@@ -38,8 +38,8 @@ class Acc38ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc38DutyDefermentContactDetailsEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getCorrespondenceAddressRequest[?(@.requestCommon.originatingSystem == 'Digital')]")

--- a/test/connectors/Acc38ConnectorSpec.scala
+++ b/test/connectors/Acc38ConnectorSpec.scala
@@ -57,7 +57,7 @@ class Acc38ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: Response = await(connector.getAccountContactDetails(AccountNumber("dan"), EORI(EORI_VALUE)))
       result mustBe response
 
-      verifyEndPointUrlHit(acc38DutyDefermentContactDetailsEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc38DutyDefermentContactDetailsEndpointUrl, POST)
     }
   }
 

--- a/test/connectors/Acc38ConnectorSpec.scala
+++ b/test/connectors/Acc38ConnectorSpec.scala
@@ -40,7 +40,7 @@ class Acc38ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.getCorrespondenceAddressRequest[?(@.requestCommon.originatingSystem == 'Digital')]")
           )

--- a/test/connectors/Acc38ConnectorSpec.scala
+++ b/test/connectors/Acc38ConnectorSpec.scala
@@ -32,7 +32,7 @@ import config.MetaConfig.Platform.MDTP
 import utils.TestData.EORI_VALUE
 import utils.Utils.emptyString
 
-import scala.concurrent.Future
+
 
 class Acc38ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc40ConnectorSpec.scala
+++ b/test/connectors/Acc40ConnectorSpec.scala
@@ -40,8 +40,8 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -68,8 +68,8 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -96,8 +96,8 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -124,8 +124,8 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")

--- a/test/connectors/Acc40ConnectorSpec.scala
+++ b/test/connectors/Acc40ConnectorSpec.scala
@@ -66,7 +66,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(NoAuthoritiesFound)
 
-      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "return Left with error response if the error message present in the response" in new Setup {
@@ -94,7 +94,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(ErrorResponse)
 
-      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "return error response when exception occurs while making the POST call" in new Setup {
@@ -171,7 +171,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           )
         )
 
-      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "search type value" should {

--- a/test/connectors/Acc40ConnectorSpec.scala
+++ b/test/connectors/Acc40ConnectorSpec.scala
@@ -18,120 +18,198 @@ package connectors
 
 import config.MetaConfig.Platform.{MDTP, REGIME_CDS}
 import domain.acc40.*
-import domain.{AuthoritiesFound, ErrorResponse, NoAuthoritiesFound}
+import domain.{Acc40Response, AuthoritiesFound, ErrorResponse, NoAuthoritiesFound}
 import models.EORI
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
 import utils.TestData.{EORI_VALUE_1, ERROR_MSG}
+import com.typesafe.config.ConfigFactory
+import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import config.MetaConfig.Platform.MDTP
 
 import scala.concurrent.Future
 
-class Acc40ConnectorSpec extends SpecBase {
+class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "searchAuthorities" should {
 
     "return Left no authorities when no authorities returned in the response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(response(None, Some("0"), None, None, None)))
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .willReturn(ok(Json.toJson(response(None, Some("0"), None, None, None)).toString))
+      )
 
-      running(app) {
-        val result = await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
-        result mustBe Left(NoAuthoritiesFound)
-      }
+      val result: Either[Acc40Response, AuthoritiesFound] =
+        await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
+
+      result mustBe Left(NoAuthoritiesFound)
+
+      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "return Left with error response if the error message present in the response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any))
-        .thenReturn(Future.successful(response(Some("error message"), Some("0"), None, None, None)))
 
-      running(app) {
-        val result = await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
-        result mustBe Left(ErrorResponse)
-      }
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .willReturn(ok(Json.toJson(response(Some("error message"), Some("0"), None, None, None)).toString))
+      )
+
+      val result: Either[Acc40Response, AuthoritiesFound] =
+        await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
+
+      result mustBe Left(ErrorResponse)
+
+      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "return error response when exception occurs while making the POST call" in new Setup {
+      val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new RuntimeException(ERROR_MSG)))
 
-      running(app) {
+      running(application) {
         val result = await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
         result mustBe Left(ErrorResponse)
       }
     }
 
     "return Right if a valid response with authorities returned" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(
-        Future.successful(
-          response(
-            None,
-            Some("1"),
-            Some(Seq(CashAccount(Account("accountNumber", "accountType", "accountOwner"), Some("10.0")))),
-            None,
-            None
-          )
-        )
-      )
 
-      running(app) {
-        val result = await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
-        result mustBe
-          Right(
-            AuthoritiesFound(
-              Some("1"),
-              None,
-              None,
-              Some(Seq(CashAccount(Account("accountNumber", "accountType", "accountOwner"), Some("10.0"))))
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc40SearchAuthoritiesEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .willReturn(
+            ok(
+              Json
+                .toJson(
+                  response(
+                    None,
+                    Some("1"),
+                    Some(Seq(CashAccount(Account("accountNumber", "accountType", "accountOwner"), Some("10.0")))),
+                    None,
+                    None
+                  )
+                )
+                .toString
             )
           )
-      }
+      )
+
+      val result: Either[Acc40Response, AuthoritiesFound] =
+        await(connector.searchAuthorities(EORI(EORI_VALUE_1), EORI(EORI_VALUE_1)))
+
+      result mustBe
+        Right(
+          AuthoritiesFound(
+            Some("1"),
+            None,
+            None,
+            Some(Seq(CashAccount(Account("accountNumber", "accountType", "accountOwner"), Some("10.0"))))
+          )
+        )
+
+      verifyEndPointUrlHit(acc40SearchAuthoritiesEndpointUrl, POST)
     }
 
     "search type value" should {
       "return 0 for GB EORI searchID" in new Setup {
-        running(app) {
-          val searchTypeValue = connector.searchType(EORI("GB123456789012"))
-          searchTypeValue mustBe "0"
-        }
+        val searchTypeValue: String = connector.searchType(EORI("GB123456789012"))
+        searchTypeValue mustBe "0"
       }
 
       "return 0 for XI EORI searchID" in new Setup {
-        running(app) {
-          val searchTypeValue = connector.searchType(EORI("XI123456789012"))
-          searchTypeValue mustBe "0"
-        }
+        val searchTypeValue: String = connector.searchType(EORI("XI123456789012"))
+        searchTypeValue mustBe "0"
       }
 
       "return 1 for account number searchID" in new Setup {
-        running(app) {
-          val searchTypeValue = connector.searchType(EORI("1234567"))
-          searchTypeValue mustBe "1"
-        }
+        val searchTypeValue: String = connector.searchType(EORI("1234567"))
+        searchTypeValue mustBe "1"
       }
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc40 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier        = HeaderCarrier()
+    val acc40SearchAuthoritiesEndpointUrl = "/customs-financials-hods-stub/accounts/searchauthorities/v1"
 
     def response(
       error: Option[String],
@@ -154,17 +232,7 @@ class Acc40ConnectorSpec extends SpecBase {
         )
       )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
+    val app: Application = application().configure(config).build()
 
     val connector: Acc40Connector = app.injector.instanceOf[Acc40Connector]
   }

--- a/test/connectors/Acc40ConnectorSpec.scala
+++ b/test/connectors/Acc40ConnectorSpec.scala
@@ -42,7 +42,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -70,7 +70,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -98,7 +98,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -126,7 +126,7 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.searchAuthoritiesRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )

--- a/test/connectors/Acc41ConnectorSpec.scala
+++ b/test/connectors/Acc41ConnectorSpec.scala
@@ -18,85 +18,172 @@ package connectors
 
 import config.MetaConfig.Platform.{MDTP, REGIME_CDS}
 import domain.acc41.*
-import domain.{Acc41ErrorResponse, AuthoritiesCsvGenerationResponse}
+import domain.{Acc41ErrorResponse, Acc41Response, AuthoritiesCsvGenerationResponse}
 import models.EORI
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
+import com.typesafe.config.ConfigFactory
+import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, ok, post, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import config.MetaConfig.Platform.MDTP
 import utils.TestData.ERROR_MSG
 import utils.Utils.emptyString
+import utils.TestData.EORI_VALUE_1
 
 import scala.concurrent.Future
 
-class Acc41ConnectorSpec extends SpecBase {
+class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "initiateAuthoritiesCSV" should {
 
     "return Left Acc41ErrorResponse when request returns error message" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(
-        Future.successful(StandingAuthoritiesForEORIResponse(response(Some("Request failed"), None)))
+
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .willReturn(
+            ok(Json.toJson(StandingAuthoritiesForEORIResponse(response(Some("Request failed"), None))).toString)
+          )
       )
 
-      running(app) {
-        val result = await(connector.initiateAuthoritiesCSV(EORI("someEori"), Some(EORI("someAltEori"))))
-        result mustBe Left(Acc41ErrorResponse)
-      }
+      val result: Either[Acc41Response, AuthoritiesCsvGenerationResponse] =
+        await(connector.initiateAuthoritiesCSV(EORI(EORI_VALUE_1), Some(EORI(EORI_VALUE_1))))
+
+      result mustBe Left(Acc41ErrorResponse)
+
+      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
 
     "return Left Acc41ErrorResponse when POST api call throws exception" in new Setup {
+      val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new RuntimeException(ERROR_MSG)))
 
-      running(app) {
+      running(application) {
         val result = await(connector.initiateAuthoritiesCSV(EORI("someEori"), Some(EORI("someAltEori"))))
         result mustBe Left(Acc41ErrorResponse)
       }
     }
 
     "return Right AuthoritiesCsvGeneration when no alternateEORI" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(
-        Future.successful(StandingAuthoritiesForEORIResponse(response(None, Some("020-06-09T21:59:56Z"))))
+
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .willReturn(
+            ok(Json.toJson(StandingAuthoritiesForEORIResponse(response(None, Some("020-06-09T21:59:56Z")))).toString)
+          )
       )
 
-      running(app) {
-        val result = await(connector.initiateAuthoritiesCSV(EORI("someEori"), Some(EORI(emptyString))))
-        result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
-      }
+      val result: Either[Acc41Response, AuthoritiesCsvGenerationResponse] =
+        await(connector.initiateAuthoritiesCSV(EORI(EORI_VALUE_1), Some(EORI(emptyString))))
+
+      result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
+
+      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
 
     "return Right AuthoritiesCsvGeneration when successful response containing a requestAcceptedDate" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(
-        Future.successful(StandingAuthoritiesForEORIResponse(response(None, Some("020-06-09T21:59:56Z"))))
+
+      wireMockServer.stubFor(
+        post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
+          .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
+          .withHeader(CONTENT_TYPE, equalTo("application/json"))
+          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.regime == 'CDS')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestDetail.requestingEORI == 'someEORI')]")
+          )
+          .withRequestBody(
+            matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestDetail.alternateEORI == 'someAltEori')]")
+          )
+          .willReturn(
+            ok(Json.toJson(StandingAuthoritiesForEORIResponse(response(None, Some("020-06-09T21:59:56Z")))).toString)
+          )
       )
 
-      running(app) {
-        val result = await(connector.initiateAuthoritiesCSV(EORI("someEori"), Some(EORI("someAltEori"))))
-        result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
-      }
+      val result: Either[Acc41Response, AuthoritiesCsvGenerationResponse] =
+        await(connector.initiateAuthoritiesCSV(EORI(EORI_VALUE_1), Some(EORI("someAltEori"))))
+
+      result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
+
+      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  acc41 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier               = HeaderCarrier()
+    val acc41AuthoritiesCsvGenerationEndpointUrl =
+      "/customs-financials-hods-stub/accounts/requeststandingauthorities/v1"
 
     def response(error: Option[String], requestAcceptedDate: Option[String]): domain.acc41.Response =
       domain.acc41.Response(
@@ -108,18 +195,7 @@ class Acc41ConnectorSpec extends SpecBase {
         )
       )
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
-
+    val app: Application          = application().configure(config).build()
     val connector: Acc41Connector = app.injector.instanceOf[Acc41Connector]
   }
 }

--- a/test/connectors/Acc41ConnectorSpec.scala
+++ b/test/connectors/Acc41ConnectorSpec.scala
@@ -41,8 +41,8 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -71,8 +71,8 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -99,8 +99,8 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -129,8 +129,8 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         post(urlPathMatching(acc41AuthoritiesCsvGenerationEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")

--- a/test/connectors/Acc41ConnectorSpec.scala
+++ b/test/connectors/Acc41ConnectorSpec.scala
@@ -71,7 +71,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Left(Acc41ErrorResponse)
 
-      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
 
     "return Left Acc41ErrorResponse when POST api call throws exception" in new Setup {
@@ -128,7 +128,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
 
-      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
 
     "return Right AuthoritiesCsvGeneration when successful response containing a requestAcceptedDate" in new Setup {
@@ -161,7 +161,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
       result mustBe Right(AuthoritiesCsvGenerationResponse(Some("020-06-09T21:59:56Z")))
 
-      verifyEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
+      verifyExactlyOneEndPointUrlHit(acc41AuthoritiesCsvGenerationEndpointUrl, POST)
     }
   }
 

--- a/test/connectors/Acc41ConnectorSpec.scala
+++ b/test/connectors/Acc41ConnectorSpec.scala
@@ -43,7 +43,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -73,7 +73,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -101,7 +101,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )
@@ -131,7 +131,7 @@ class Acc41ConnectorSpec extends SpecBase with WireMockSupportProvider {
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withRequestBody(
             matchingJsonPath("$.standingAuthoritiesForEORIRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
           )

--- a/test/connectors/Acc44ConnectorSpec.scala
+++ b/test/connectors/Acc44ConnectorSpec.scala
@@ -37,7 +37,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+
 
 class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Acc44ConnectorSpec.scala
+++ b/test/connectors/Acc44ConnectorSpec.scala
@@ -38,8 +38,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.{
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import config.MetaConfig.Platform.MDTP
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "cashAccountTransactionSearch" should {

--- a/test/connectors/Acc44ConnectorSpec.scala
+++ b/test/connectors/Acc44ConnectorSpec.scala
@@ -49,8 +49,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -82,8 +82,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -143,8 +143,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -174,8 +174,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -205,8 +205,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -245,8 +245,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -285,8 +285,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -316,8 +316,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -347,8 +347,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -378,8 +378,8 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc44CashTransactionSearchEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountTransactionSearchRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")

--- a/test/connectors/Acc44ConnectorSpec.scala
+++ b/test/connectors/Acc44ConnectorSpec.scala
@@ -74,7 +74,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Right(cashAccTranSearchResponseContainerWithDeclarationOb)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "response has paymentsWithdrawalsAndTransfers" in new Setup {
@@ -107,7 +107,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Right(cashAccTranSearchResponseContainerOb)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
     }
 
@@ -166,7 +166,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Right(cashAccTranSearchResponseContainerWith201EISCodeOb)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "EIS returns 201 to MDTP with errorDetails" in new Setup {
@@ -197,7 +197,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "api call produces Http status 500 due to backEnd error" in new Setup {
@@ -228,7 +228,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "request times out with Http status 500 due to EIS system error" in new Setup {
@@ -268,7 +268,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "request times out with Http status 400 due to EIS schema error" in new Setup {
@@ -308,7 +308,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "INTERNAL_SERVER_ERROR is returned from ETMP" in new Setup {
@@ -339,7 +339,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "4xx error is returned from ETMP" in new Setup {
@@ -370,7 +370,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "api call produces Http status code apart from 200, 400, 500 due to backEnd error with errorDetails" in new Setup {
@@ -401,7 +401,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
         result mustBe Left(errorDetails)
 
-        verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
       }
 
       "api call produces Http status code apart from 200, 400, 500 due to backEnd error with object other " +
@@ -445,7 +445,7 @@ class Acc44ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
           result mustBe Left(errorDetails)
 
-          verifyEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
+          verifyExactlyOneEndPointUrlHit(acc44CashTransactionSearchEndpointUrl, POST)
         }
     }
   }

--- a/test/connectors/Acc45ConnectorSpec.scala
+++ b/test/connectors/Acc45ConnectorSpec.scala
@@ -26,7 +26,6 @@ import org.mockito.Mockito.when
 import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.Json
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}

--- a/test/connectors/Acc45ConnectorSpec.scala
+++ b/test/connectors/Acc45ConnectorSpec.scala
@@ -69,7 +69,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Right(responseCommon01)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "request is not successful due to business error - 'Request could not be processed'" in new Setup {
@@ -95,7 +95,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Right(responseCommon02)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "request is not successful due to business error - 'Exceeded maximum threshold of transactions'" in new Setup {
@@ -121,7 +121,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Right(responseCommon03)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
     }
 
@@ -149,7 +149,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Left(errorResponseDetails01)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "requests has missing required properties" in new Setup {
@@ -175,7 +175,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Left(errorResponseDetails02)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "Backend system faces Internal Server Error" in new Setup {
@@ -201,7 +201,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[ErrorDetail, Acc45ResponseCommon] = await(connector.submitStatementRequest(reqDetail01))
         result mustBe Left(errorResponseDetails03)
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "Backend system sends ServiceUnavailable error" in new Setup {
@@ -230,7 +230,7 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         errorDetail.errorCode mustBe SERVICE_UNAVAILABLE.toString
         errorDetail.errorMessage must not be empty
 
-        verifyEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(acc45CashAccountStatementRequestEndpointUrl, POST)
       }
 
       "Not Found Error is thrown from API call" in new Setup {

--- a/test/connectors/Acc45ConnectorSpec.scala
+++ b/test/connectors/Acc45ConnectorSpec.scala
@@ -45,8 +45,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -71,8 +71,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -97,8 +97,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -125,8 +125,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -151,8 +151,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -177,8 +177,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -203,8 +203,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")
@@ -232,8 +232,8 @@ class Acc45ConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(acc45CashAccountStatementRequestEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.cashAccountStatementRequest[?(@.requestCommon.originatingSystem == 'MDTP')]")

--- a/test/connectors/Acc45ConnectorSpec.scala
+++ b/test/connectors/Acc45ConnectorSpec.scala
@@ -28,7 +28,7 @@ import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
+import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
 import utils.{SpecBase, WireMockSupportProvider}
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json.Json

--- a/test/connectors/DataStoreConnectorSpec.scala
+++ b/test/connectors/DataStoreConnectorSpec.scala
@@ -19,42 +19,66 @@ package connectors
 import models.{AddressInformation, CompanyInformation, EORI, EmailAddress}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
 import utils.TestData.COUNTRY_CODE_GB
+import com.typesafe.config.ConfigFactory
+import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.client.WireMock.{get, ok, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import utils.TestData.EORI_VALUE_1
 
-class DataStoreConnectorSpec extends SpecBase {
+class DataStoreConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "getVerifiedEmail" should {
 
     "return the email from the data-store response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(emailResponse))
 
-      running(app) {
-        val result = await(connector.getVerifiedEmail(EORI("someEori")))
-        result mustBe emailResponse.address
-      }
+      wireMockServer.stubFor(
+        get(urlPathMatching(customDataStoreVerifiedEmailUrl))
+          .willReturn(ok(Json.toJson(emailResponse).toString))
+      )
+
+      val result: Option[EmailAddress] = await(connector.getVerifiedEmail(EORI(EORI_VALUE_1)))
+      result mustBe emailResponse.address
+
+      verifyEndPointUrlHit(customDataStoreVerifiedEmailUrl, GET)
     }
 
     "return None when an unknown exception happens from the data-store" in new Setup {
+      val mockHttpClient: HttpClientV2          = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder        = mock[RequestBuilder]
+      implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        val result = await(connector.getVerifiedEmail(EORI("someEori")))
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
+      val dataStoreConnector: DataStoreConnector = application.injector.instanceOf[DataStoreConnector]
+
+      running(application) {
+        val result = await(dataStoreConnector.getVerifiedEmail(EORI(EORI_VALUE_1)))
         result mustBe None
       }
     }
@@ -63,25 +87,43 @@ class DataStoreConnectorSpec extends SpecBase {
   "getEoriHistory" should {
 
     "return EORIHistory on a successful response from the data-store" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(eoriHistoryResponse))
+      wireMockServer.stubFor(
+        get(urlPathMatching(customDataStoreEoriHistoryUrl))
+          .willReturn(ok(Json.toJson(eoriHistoryResponse).toString))
+      )
 
-      running(app) {
-        val result = await(connector.getEoriHistory(EORI("someEori")))
-        result mustBe Seq(EORI("someEori"))
-      }
+      val result: Seq[EORI] = await(connector.getEoriHistory(EORI(EORI_VALUE_1)))
+      result mustBe Seq(EORI(EORI_VALUE_1))
+
+      verifyEndPointUrlHit(customDataStoreEoriHistoryUrl, GET)
     }
 
     "return an empty sequence if an exception was thrown from the data-store" in new Setup {
+      val mockHttpClient: HttpClientV2          = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder        = mock[RequestBuilder]
+      implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        val result = await(connector.getEoriHistory(EORI("someEori")))
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
+      val dataStoreConnector: DataStoreConnector = application.injector.instanceOf[DataStoreConnector]
+
+      running(application) {
+        val result = await(dataStoreConnector.getEoriHistory(EORI(EORI_VALUE_1)))
         result mustBe Seq.empty
       }
     }
@@ -90,68 +132,91 @@ class DataStoreConnectorSpec extends SpecBase {
   "getCompanyName" should {
 
     "return companyName on a successful response from the data-store" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(companyNameResponse))
 
-      running(app) {
-        connector.getCompanyName(EORI("someEori")).map { cname =>
-          cname mustBe Some("test_company")
-        }
-      }
+      wireMockServer.stubFor(
+        get(urlPathMatching(customDataStoreCompanyInfoUrl))
+          .willReturn(ok(Json.toJson(companyNameResponse).toString))
+      )
+
+      val result: Option[String] = await(connector.getCompanyName(EORI(EORI_VALUE_1)))
+      result mustBe Some("test_company")
+
+      verifyEndPointUrlHit(customDataStoreCompanyInfoUrl, GET)
     }
 
-    "return None when consent returned is other than 1" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(companyNameResponse.copy(consent = "2")))
+    "return companyName when consent returned is other than 1" in new Setup {
 
-      running(app) {
-        connector.getCompanyName(EORI("someEori")).map { cname =>
-          cname mustBe None
-        }
-      }
+      wireMockServer.stubFor(
+        get(urlPathMatching(customDataStoreCompanyInfoUrl))
+          .willReturn(ok(Json.toJson(companyNameResponse.copy(consent = "2")).toString))
+      )
+
+      val result: Option[String] = await(connector.getCompanyName(EORI(EORI_VALUE_1)))
+      result mustBe Some("test_company")
+
+      verifyEndPointUrlHit(customDataStoreCompanyInfoUrl, GET)
     }
 
-    "return None when an unknown exception happens from the data-store" in new Setup {
+    "return None when an unknown exception happens from the data-store" in {
+      val mockHttpClient: HttpClientV2          = mock[HttpClientV2]
+      val requestBuilder: RequestBuilder        = mock[RequestBuilder]
+      implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
       when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
       when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
       when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
       when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-      running(app) {
-        connector.getCompanyName(EORI("someEori")).map { cname =>
+      val application: Application = GuiceApplicationBuilder()
+        .overrides(
+          bind[HttpClientV2].toInstance(mockHttpClient),
+          bind[RequestBuilder].toInstance(requestBuilder)
+        )
+        .configure(
+          "microservice.metrics.enabled" -> false,
+          "metrics.enabled"              -> false,
+          "auditing.enabled"             -> false
+        )
+        .build()
+
+      val dataStoreConnector: DataStoreConnector = application.injector.instanceOf[DataStoreConnector]
+
+      running(application) {
+        dataStoreConnector.getCompanyName(EORI(EORI_VALUE_1)).map { cname =>
           cname mustBe None
         }
       }
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  customs-data-store {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+    implicit val hc: HeaderCarrier      = HeaderCarrier()
+    val customDataStoreVerifiedEmailUrl = "/customs-data-store/eori/someEORI/verified-email"
+    val customDataStoreEoriHistoryUrl   = "/customs-data-store/eori/someEORI/eori-history"
+    val customDataStoreCompanyInfoUrl   = "/customs-data-store/eori/someEORI/company-information"
 
     val emailResponse: EmailResponse             = EmailResponse(Some(EmailAddress("some@email.com")), None)
-    val eoriHistoryResponse: EoriHistoryResponse = EoriHistoryResponse(Seq(EoriPeriod(EORI("someEori"), None, None)))
+    val eoriHistoryResponse: EoriHistoryResponse = EoriHistoryResponse(Seq(EoriPeriod(EORI(EORI_VALUE_1), None, None)))
 
     val companyNameResponse: CompanyInformation =
       CompanyInformation("test_company", "1", AddressInformation("1", "Kailash", None, COUNTRY_CODE_GB))
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
-
+    val app: Application              = application().configure(config).build()
     val connector: DataStoreConnector = app.injector.instanceOf[DataStoreConnector]
   }
 }

--- a/test/connectors/EmailThrottlerConnectorSpec.scala
+++ b/test/connectors/EmailThrottlerConnectorSpec.scala
@@ -28,8 +28,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalToJson, 
 import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 
-import scala.concurrent.Future
-
 class EmailThrottlerConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "return true when the api responds with 202" in new Setup {

--- a/test/connectors/EmailThrottlerConnectorSpec.scala
+++ b/test/connectors/EmailThrottlerConnectorSpec.scala
@@ -18,7 +18,6 @@ package connectors
 
 import models.requests.EmailRequest
 import play.api.{Application, Configuration}
-import play.api.inject.bind
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
@@ -69,6 +68,8 @@ class EmailThrottlerConnectorSpec extends SpecBase with WireMockSupportProvider 
 
     val result: Boolean = await(connector.sendEmail(request))
     result mustBe false
+
+    verifyEndPointUrlHit(sendEmailEndpointUrl, POST)
   }
 
   override def config: Configuration = Configuration(

--- a/test/connectors/EmailThrottlerConnectorSpec.scala
+++ b/test/connectors/EmailThrottlerConnectorSpec.scala
@@ -43,7 +43,7 @@ class EmailThrottlerConnectorSpec extends SpecBase with WireMockSupportProvider 
     val result: Boolean = await(connector.sendEmail(request))
     result mustBe true
 
-    verifyEndPointUrlHit(sendEmailEndpointUrl, POST)
+    verifyExactlyOneEndPointUrlHit(sendEmailEndpointUrl, POST)
   }
 
   "return false when the api responds with a successful response that isn't 204" in new Setup {
@@ -57,7 +57,7 @@ class EmailThrottlerConnectorSpec extends SpecBase with WireMockSupportProvider 
     val result: Boolean = await(connector.sendEmail(request))
     result mustBe false
 
-    verifyEndPointUrlHit(sendEmailEndpointUrl, POST)
+    verifyExactlyOneEndPointUrlHit(sendEmailEndpointUrl, POST)
   }
 
   "return false when the api fails due to connection reset" in new Setup {

--- a/test/connectors/EmailThrottlerConnectorSpec.scala
+++ b/test/connectors/EmailThrottlerConnectorSpec.scala
@@ -19,63 +19,60 @@ package connectors
 import models.requests.EmailRequest
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, NotFoundException}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
 import utils.Utils.emptyString
+import com.typesafe.config.ConfigFactory
+import play.api.libs.json.Json
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalToJson, ok, post, serverError, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 
 import scala.concurrent.Future
 
-class EmailThrottlerConnectorSpec extends SpecBase {
+class EmailThrottlerConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "return true when the api responds with 202" in new Setup {
-    when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-    when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-    when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-    when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(ACCEPTED, emptyString)))
+    wireMockServer.stubFor(
+      post(urlPathMatching(sendEmailEndpointUrl))
+        .withRequestBody(equalToJson(Json.toJson(request).toString))
+        .willReturn(aResponse().withStatus(ACCEPTED).withBody(emptyString))
+    )
 
-    running(app) {
-      val result = await(connector.sendEmail(request))
-      result mustBe true
-    }
+    val result: Boolean = await(connector.sendEmail(request))
+    result mustBe true
+
+    verifyEndPointUrlHit(sendEmailEndpointUrl, POST)
   }
 
   "return false when the api responds with a successful response that isn't 204" in new Setup {
-    when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-    when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-    when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
-    when(requestBuilder.execute(any, any)).thenReturn(Future.successful(HttpResponse(OK, emptyString)))
 
-    running(app) {
-      val result = await(connector.sendEmail(request))
-      result mustBe false
-    }
+    wireMockServer.stubFor(
+      post(urlPathMatching(sendEmailEndpointUrl))
+        .withRequestBody(equalToJson(Json.toJson(request).toString))
+        .willReturn(ok(emptyString))
+    )
+
+    val result: Boolean = await(connector.sendEmail(request))
+    result mustBe false
+
+    verifyEndPointUrlHit(sendEmailEndpointUrl, POST)
   }
 
   "return false when the api fails" in new Setup {
+    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
+    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
     when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
     when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
     when(mockHttpClient.post(any)(any)).thenReturn(requestBuilder)
     when(requestBuilder.execute(any, any)).thenReturn(Future.failed(new NotFoundException("error")))
 
-    running(app) {
-      val result = await(connector.sendEmail(request))
-      result mustBe false
-    }
-  }
-
-  trait Setup {
-    implicit val hc: HeaderCarrier     = HeaderCarrier()
-    val mockHttpClient: HttpClientV2   = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder = mock[RequestBuilder]
-
-    val request: EmailRequest = EmailRequest(List.empty, emptyString, Map.empty, force = true, None, Some("eori"), None)
-
-    val app: Application = GuiceApplicationBuilder()
+    val application: Application = GuiceApplicationBuilder()
       .overrides(
         bind[HttpClientV2].toInstance(mockHttpClient),
         bind[RequestBuilder].toInstance(requestBuilder)
@@ -87,6 +84,36 @@ class EmailThrottlerConnectorSpec extends SpecBase {
       )
       .build()
 
+    val emailThrottlerConnector: EmailThrottlerConnector = application.injector.instanceOf[EmailThrottlerConnector]
+
+    running(application) {
+      val result = await(emailThrottlerConnector.sendEmail(request))
+      result mustBe false
+    }
+  }
+
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  customs-financials-email-throttler {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
+  trait Setup {
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val sendEmailEndpointUrl       = "/customs-financials-email-throttler/enqueue-email"
+
+    val request: EmailRequest = EmailRequest(List.empty, emptyString, Map.empty, force = true, None, Some("eori"), None)
+
+    val app: Application                   = application().configure(config).build()
     val connector: EmailThrottlerConnector = app.injector.instanceOf[EmailThrottlerConnector]
   }
 }

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -22,7 +22,6 @@ import domain.secureMessage.*
 import models.*
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.inject.bind
 import play.api.test.Helpers.running
 import play.api.{Application, Configuration, inject}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -90,8 +90,8 @@ class SecureMessageConnectorSpec extends SpecBase with WireMockSupportProvider {
         wireMockServer.stubFor(
           post(urlPathMatching(secureMessageEndpointUrl))
             .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-            .withHeader(CONTENT_TYPE, equalTo("application/json"))
-            .withHeader(ACCEPT, equalTo("application/json"))
+            .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+            .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
             .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
             .withRequestBody(
               matchingJsonPath("$.recipient[?(@.regime == 'cds')]")

--- a/test/connectors/SecureMessageConnectorSpec.scala
+++ b/test/connectors/SecureMessageConnectorSpec.scala
@@ -108,7 +108,7 @@ class SecureMessageConnectorSpec extends SpecBase with WireMockSupportProvider {
         val result: Either[String, Response] = await(connector.sendSecureMessage(histDoc = doc))
         result mustBe Right(Response(eori.value))
 
-        verifyEndPointUrlHit(secureMessageEndpointUrl, POST)
+        verifyExactlyOneEndPointUrlHit(secureMessageEndpointUrl, POST)
       }
 
       "return error response when exception occurs while getting VerifiedEmail" in new Setup {

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -53,10 +53,47 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
       )
 
       val result: SubscriptionResponse = await(connector.getSubscriptions(EORI(EORI_VALUE_1)))
-      result mustBe response
+
+      shouldOutputCorrectSubscriptionResponse(result, response)
 
       verifyExactlyOneEndPointUrlHit(sub09GetSubscriptionsEndpointUrl, GET)
     }
+  }
+
+  private def shouldOutputCorrectSubscriptionResponse(
+    actualResponse: SubscriptionResponse,
+    expectedResponse: SubscriptionResponse
+  ) = {
+    actualResponse.subscriptionDisplayResponse.responseCommon mustBe
+      expectedResponse.subscriptionDisplayResponse.responseCommon
+
+    val actualResponseDetails: ResponseDetail   = actualResponse.subscriptionDisplayResponse.responseDetail
+    val expectedResponseDetails: ResponseDetail = expectedResponse.subscriptionDisplayResponse.responseDetail
+
+    actualResponseDetails.EORINo mustBe expectedResponseDetails.EORINo
+    actualResponseDetails.EORIStartDate mustBe expectedResponseDetails.EORIStartDate
+    actualResponseDetails.EORIEndDate mustBe expectedResponseDetails.EORIEndDate
+    actualResponseDetails.CDSFullName mustBe expectedResponseDetails.CDSFullName
+    actualResponseDetails.CDSEstablishmentAddress mustBe expectedResponseDetails.CDSEstablishmentAddress
+    actualResponseDetails.XI_Subscription mustBe actualResponseDetails.XI_Subscription
+    actualResponseDetails.establishmentInTheCustomsTerritoryOfTheUnion mustBe
+      expectedResponseDetails.establishmentInTheCustomsTerritoryOfTheUnion
+
+    actualResponseDetails.typeOfLegalEntity mustBe expectedResponseDetails.typeOfLegalEntity
+    actualResponseDetails.contactInformation mustBe expectedResponseDetails.contactInformation
+    actualResponseDetails.VATIDs.getOrElse(Array[VatId]()) mustBe expectedResponseDetails.VATIDs.getOrElse(
+      Array[VatId]()
+    )
+    actualResponseDetails.thirdCountryUniqueIdentificationNumber mustBe
+      expectedResponseDetails.thirdCountryUniqueIdentificationNumber
+
+    actualResponseDetails.consentToDisclosureOfPersonalData mustBe
+      expectedResponseDetails.consentToDisclosureOfPersonalData
+
+    actualResponseDetails.shortName mustBe expectedResponseDetails.shortName
+    actualResponseDetails.dateOfEstablishment mustBe expectedResponseDetails.dateOfEstablishment
+    actualResponseDetails.typeOfPerson mustBe expectedResponseDetails.typeOfPerson
+    actualResponseDetails.ETMP_Master_Indicator mustBe expectedResponseDetails.ETMP_Master_Indicator
   }
 
   override def config: Configuration = Configuration(

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -61,7 +61,7 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: SubscriptionResponse = await(connector.getSubscriptions(EORI(EORI_VALUE_1)))
       result mustBe response
 
-      verifyEndPointUrlHit(sub09GetSubscriptionsEndpointUrl, GET)
+      verifyExactlyOneEndPointUrlHit(sub09GetSubscriptionsEndpointUrl, GET)
     }
   }
 

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -18,18 +18,13 @@ package connectors
 
 import domain.sub09.*
 import models.EORI
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import utils.{SpecBase, WireMockSupportProvider}
 import utils.TestData.COUNTRY_CODE_GB
 import play.api.libs.json.Json
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, matchingJsonPath, ok, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, ok, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import config.MetaConfig.Platform.{MDTP, REGIME_CDS}
@@ -38,7 +33,6 @@ import com.typesafe.config.ConfigFactory
 
 import java.util
 import scala.jdk.CollectionConverters.MapHasAsJava
-import scala.concurrent.Future
 
 class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -45,8 +45,8 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
       wireMockServer.stubFor(
         get(urlPathMatching(sub09GetSubscriptionsEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
-          .withHeader(CONTENT_TYPE, equalTo("application/json"))
-          .withHeader(ACCEPT, equalTo("application/json"))
+          .withHeader(CONTENT_TYPE, equalTo(CONTENT_TYPE_APPLICATION_JSON))
+          .withHeader(ACCEPT, equalTo(CONTENT_TYPE_APPLICATION_JSON))
           .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
           .withQueryParams(queryParams)
           .willReturn(ok(Json.toJson(response).toString))

--- a/test/connectors/Sub09ConnectorSpec.scala
+++ b/test/connectors/Sub09ConnectorSpec.scala
@@ -31,10 +31,13 @@ import utils.TestData.COUNTRY_CODE_GB
 import play.api.libs.json.Json
 import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, matchingJsonPath, ok, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import config.MetaConfig.Platform.{MDTP, REGIME_CDS}
 import utils.TestData.EORI_VALUE_1
 import com.typesafe.config.ConfigFactory
 
+import java.util
+import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.concurrent.Future
 
 class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
@@ -42,14 +45,16 @@ class Sub09ConnectorSpec extends SpecBase with WireMockSupportProvider {
   "getSubscriptions" should {
     "return a json on a successful response" in new Setup {
 
+      val queryParams: util.Map[String, StringValuePattern] =
+        Map(PARAM_NAME_EORI -> equalTo(EORI_VALUE_1), PARAM_NAME_REGIME -> equalTo(REGIME_CDS)).asJava
+
       wireMockServer.stubFor(
         get(urlPathMatching(sub09GetSubscriptionsEndpointUrl))
           .withHeader(X_FORWARDED_HOST, equalTo(MDTP))
           .withHeader(CONTENT_TYPE, equalTo("application/json"))
           .withHeader(ACCEPT, equalTo("application/json"))
-          .withHeader(AUTHORIZATION, equalTo("Bearer test1234567"))
-          .withQueryParam("EORI", equalTo(EORI_VALUE_1))
-          .withQueryParam("regime", equalTo(REGIME_CDS))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
+          .withQueryParams(queryParams)
           .willReturn(ok(Json.toJson(response).toString))
       )
 

--- a/test/connectors/Sub21ConnectorSpec.scala
+++ b/test/connectors/Sub21ConnectorSpec.scala
@@ -51,7 +51,7 @@ class Sub21ConnectorSpec extends SpecBase with WireMockSupportProvider {
       val result: HistoricEoriResponse = await(connector.getEORIHistory(EORI(EORI_VALUE_1)))
       result mustBe response
 
-      verifyEndPointUrlHit(sub21CheckEORIValidEndpointUrl, GET)
+      verifyExactlyOneEndPointUrlHit(sub21CheckEORIValidEndpointUrl, GET)
     }
   }
 

--- a/test/connectors/Sub21ConnectorSpec.scala
+++ b/test/connectors/Sub21ConnectorSpec.scala
@@ -16,25 +16,18 @@
 
 package connectors
 
-import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import models.EORI
 import models.responses.*
 import play.api.{Application, Configuration}
-import play.api.inject.bind
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{SpecBase, WireMockSupportProvider}
 import utils.Utils.emptyString
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, matchingJsonPath, ok, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, ok, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET
-import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import play.api.libs.json.Json
 import utils.TestData.EORI_VALUE_1
 import com.typesafe.config.ConfigFactory
-import config.MetaConfig.Platform.MDTP
-
-
 
 class Sub21ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/connectors/Sub21ConnectorSpec.scala
+++ b/test/connectors/Sub21ConnectorSpec.scala
@@ -16,43 +16,68 @@
 
 package connectors
 
+import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import models.EORI
 import models.responses.*
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.Application
+import play.api.{Application, Configuration}
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import utils.SpecBase
+import utils.{SpecBase, WireMockSupportProvider}
 import utils.Utils.emptyString
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, get, matchingJsonPath, ok, urlPathMatching}
+import com.github.tomakehurst.wiremock.http.RequestMethod.GET
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import play.api.libs.json.Json
+import utils.TestData.EORI_VALUE_1
+import com.typesafe.config.ConfigFactory
+import config.MetaConfig.Platform.MDTP
 
 import scala.concurrent.Future
 
-class Sub21ConnectorSpec extends SpecBase {
+class Sub21ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
   "getEoriHistory" should {
     "return a json on a successful response" in new Setup {
-      when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
-      when(requestBuilder.setHeader(any[(String, String)]())).thenReturn(requestBuilder)
-      when(mockHttpClient.get(any)(any)).thenReturn(requestBuilder)
-      when(requestBuilder.execute(any, any)).thenReturn(Future.successful(response))
 
-      running(app) {
-        val result = await(connector.getEORIHistory(EORI("someEori")))
-        result mustBe response
-      }
+      wireMockServer.stubFor(
+        get(urlPathMatching(sub21CheckEORIValidEndpointUrl))
+          .withHeader(AUTHORIZATION, equalTo(AUTH_BEARER_TOKEN_VALUE))
+          .withQueryParam(PARAM_NAME_eori, equalTo(EORI_VALUE_1))
+          .willReturn(ok(Json.toJson(response).toString))
+      )
+
+      val result: HistoricEoriResponse = await(connector.getEORIHistory(EORI(EORI_VALUE_1)))
+      result mustBe response
+
+      verifyEndPointUrlHit(sub21CheckEORIValidEndpointUrl, GET)
     }
   }
 
+  override def config: Configuration = Configuration(
+    ConfigFactory.parseString(
+      s"""
+         |microservice {
+         |  services {
+         |  sub21 {
+         |            host = $wireMockHost
+         |            port = $wireMockPort
+         |        }
+         |  }
+         |}
+         |""".stripMargin
+    )
+  )
+
   trait Setup {
-    implicit val hc: HeaderCarrier                           = HeaderCarrier()
-    val mockHttpClient: HttpClientV2                         = mock[HttpClientV2]
-    val requestBuilder: RequestBuilder                       = mock[RequestBuilder]
-    val responseCommon: EORIHistoryResponseCommon            = EORIHistoryResponseCommon("OK", emptyString)
-    val eoriHistory: EORIHistory                             = EORIHistory(EORI("1212"), Some("1211"), Some("12121"))
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val sub21CheckEORIValidEndpointUrl = "/customs-financials-hods-stub/subscriptions/geteorihistory/v1"
+
+    val responseCommon: EORIHistoryResponseCommon = EORIHistoryResponseCommon("OK", emptyString)
+    val eoriHistory: EORIHistory                  = EORIHistory(EORI("1212"), Some("1211"), Some("12121"))
+
     val eoriHistoryResponseDetail: EORIHistoryResponseDetail = EORIHistoryResponseDetail(
       Array(eoriHistory).toIndexedSeq
     )
@@ -60,18 +85,7 @@ class Sub21ConnectorSpec extends SpecBase {
     val response: HistoricEoriResponse =
       HistoricEoriResponse(GetEORIHistoryResponse(responseCommon, eoriHistoryResponseDetail))
 
-    val app: Application = GuiceApplicationBuilder()
-      .overrides(
-        bind[HttpClientV2].toInstance(mockHttpClient),
-        bind[RequestBuilder].toInstance(requestBuilder)
-      )
-      .configure(
-        "microservice.metrics.enabled" -> false,
-        "metrics.enabled"              -> false,
-        "auditing.enabled"             -> false
-      )
-      .build()
-
+    val app: Application          = application().configure(config).build()
     val connector: Sub21Connector = app.injector.instanceOf[Sub21Connector]
   }
 }

--- a/test/connectors/Sub21ConnectorSpec.scala
+++ b/test/connectors/Sub21ConnectorSpec.scala
@@ -34,7 +34,7 @@ import utils.TestData.EORI_VALUE_1
 import com.typesafe.config.ConfigFactory
 import config.MetaConfig.Platform.MDTP
 
-import scala.concurrent.Future
+
 
 class Sub21ConnectorSpec extends SpecBase with WireMockSupportProvider {
 

--- a/test/models/responses/StandingAuthoritiesResponseSpec.scala
+++ b/test/models/responses/StandingAuthoritiesResponseSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.responses
+
+import domain.{AccountWithAuthorities, StandingAuthority}
+import models.{AccountNumber, AccountStatus, AccountType, EORI}
+import play.api.libs.json.{JsSuccess, Json}
+import utils.SpecBase
+import utils.TestData.{BANK_ACCOUNT, DATE_STRING, EORI_VALUE_1}
+
+class StandingAuthoritiesResponseSpec extends SpecBase {
+
+  "Json Reads" should {
+    "generate correct output" in new Setup {
+      import StandingAuthoritiesResponse.standingAuthoritiesRequestReads
+
+      Json.fromJson(Json.parse(standingAuthoritiesResponseJsonString)) mustBe JsSuccess(
+        standingAuthoritiesResponseObject
+      )
+    }
+  }
+
+  "Json Writes" should {
+    "generate correct output" in new Setup {
+      Json.toJson(standingAuthoritiesResponseObject) mustBe Json.parse(standingAuthoritiesResponseJsonString)
+    }
+  }
+
+  trait Setup {
+
+    val standingAuthoritiesResponseJsonString: String =
+      """{
+        |"ownerEori":"someEORI",
+        |"accounts":[{
+        |"accountType":"CDSCash",
+        |"accountNumber":"1234567890987",
+        |"accountStatus":"Open",
+        |"authorities":[{
+        |"authorisedEori":"someEORI",
+        |"authorisedFromDate":"2024-05-28",
+        |"viewBalance":true,
+        |"authorisedToDate":"2024-05-28"
+        |}]
+        |}]
+        |}""".stripMargin
+
+    val accountAuthority: StandingAuthority =
+      StandingAuthority(EORI(EORI_VALUE_1), DATE_STRING, Some(DATE_STRING), true)
+
+    val accountWithAuthorities: Seq[AccountWithAuthorities] =
+      Seq(
+        AccountWithAuthorities(
+          AccountType("CDSCash"),
+          AccountNumber(BANK_ACCOUNT),
+          AccountStatus("Open"),
+          Seq(accountAuthority)
+        )
+      )
+
+    val standingAuthoritiesResponseObject: StandingAuthoritiesResponse =
+      StandingAuthoritiesResponse(EORI(EORI_VALUE_1), accountWithAuthorities)
+  }
+}

--- a/test/models/responses/StandingAuthoritiesResponseSpec.scala
+++ b/test/models/responses/StandingAuthoritiesResponseSpec.scala
@@ -24,18 +24,17 @@ import utils.TestData.{BANK_ACCOUNT, DATE_STRING, EORI_VALUE_1}
 
 class StandingAuthoritiesResponseSpec extends SpecBase {
 
-  "Json Reads" should {
-    "generate correct output" in new Setup {
-      import StandingAuthoritiesResponse.standingAuthoritiesRequestReads
+  "standingAuthoritiesResponseFormat" should {
+
+    "generate correct output for Json Reads" in new Setup {
+      import StandingAuthoritiesResponse.standingAuthoritiesResponseFormat
 
       Json.fromJson(Json.parse(standingAuthoritiesResponseJsonString)) mustBe JsSuccess(
         standingAuthoritiesResponseObject
       )
     }
-  }
 
-  "Json Writes" should {
-    "generate correct output" in new Setup {
+    "generate correct output for Json Writes" in new Setup {
       Json.toJson(standingAuthoritiesResponseObject) mustBe Json.parse(standingAuthoritiesResponseJsonString)
     }
   }

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -18,7 +18,11 @@ package utils
 import play.api.Configuration
 import uk.gov.hmrc.http.test.WireMockSupport
 import org.scalatest.Suite
-import com.github.tomakehurst.wiremock.client.WireMock.{getRequestedFor, urlPathMatching}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  getRequestedFor, postRequestedFor, put, putRequestedFor, urlPathMatching
+}
+import com.github.tomakehurst.wiremock.http.RequestMethod
+import com.github.tomakehurst.wiremock.http.RequestMethod.{DELETE, GET, POST, PUT}
 
 trait WireMockSupportProvider extends WireMockSupport {
   me: Suite =>
@@ -30,9 +34,13 @@ trait WireMockSupportProvider extends WireMockSupport {
 
   def config: Configuration
 
-  protected def verifyEndPointUrlHit(urlToVerify: String): Unit = wireMockServer.verify(
-    getRequestedFor(
-      urlPathMatching(urlToVerify)
+  protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET): Unit =
+    wireMockServer.verify(
+      methodType match {
+        case POST => postRequestedFor(urlPathMatching(urlToVerify))
+        case PUT  => putRequestedFor(urlPathMatching(urlToVerify))
+        case GET  => getRequestedFor(urlPathMatching(urlToVerify))
+        case _    => throw new RuntimeException("Invalid method type")
+      }
     )
-  )
 }

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -25,7 +25,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod
 import com.github.tomakehurst.wiremock.http.RequestMethod.{DELETE, GET, POST, PUT}
 
 trait WireMockSupportProvider extends WireMockSupport {
-  me: Suite =>
+  this: Suite =>
 
   val X_FORWARDED_HOST = "X-Forwarded-Host"
   val CONTENT_TYPE     = "Content-Type"

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -32,7 +32,8 @@ trait WireMockSupportProvider extends WireMockSupport {
   val ACCEPT           = "Accept"
   val AUTHORIZATION    = "Authorization"
 
-  val AUTH_BEARER_TOKEN_VALUE = "Bearer test1234567"
+  val AUTH_BEARER_TOKEN_VALUE       = "Bearer test1234567"
+  val CONTENT_TYPE_APPLICATION_JSON = "application/json"
 
   val PARAM_NAME_EORI   = "EORI"
   val PARAM_NAME_eori   = "eori"

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -32,6 +32,12 @@ trait WireMockSupportProvider extends WireMockSupport {
   val ACCEPT           = "Accept"
   val AUTHORIZATION    = "Authorization"
 
+  val AUTH_BEARER_TOKEN_VALUE = "Bearer test1234567"
+
+  val PARAM_NAME_EORI   = "EORI"
+  val PARAM_NAME_eori   = "eori"
+  val PARAM_NAME_REGIME = "regime"
+
   def config: Configuration
 
   protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET, count: Int = 1): Unit =

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -34,8 +34,9 @@ trait WireMockSupportProvider extends WireMockSupport {
 
   def config: Configuration
 
-  protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET): Unit =
+  protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET, count: Int = 1): Unit =
     wireMockServer.verify(
+      count,
       methodType match {
         case GET    => getRequestedFor(urlPathMatching(urlToVerify))
         case POST   => postRequestedFor(urlPathMatching(urlToVerify))

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -19,7 +19,7 @@ import play.api.Configuration
 import uk.gov.hmrc.http.test.WireMockSupport
 import org.scalatest.Suite
 import com.github.tomakehurst.wiremock.client.WireMock.{
-  getRequestedFor, postRequestedFor, put, putRequestedFor, urlPathMatching
+  deleteRequestedFor, getRequestedFor, postRequestedFor, put, putRequestedFor, urlPathMatching
 }
 import com.github.tomakehurst.wiremock.http.RequestMethod
 import com.github.tomakehurst.wiremock.http.RequestMethod.{DELETE, GET, POST, PUT}
@@ -37,10 +37,11 @@ trait WireMockSupportProvider extends WireMockSupport {
   protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET): Unit =
     wireMockServer.verify(
       methodType match {
-        case POST => postRequestedFor(urlPathMatching(urlToVerify))
-        case PUT  => putRequestedFor(urlPathMatching(urlToVerify))
-        case GET  => getRequestedFor(urlPathMatching(urlToVerify))
-        case _    => throw new RuntimeException("Invalid method type")
+        case GET    => getRequestedFor(urlPathMatching(urlToVerify))
+        case POST   => postRequestedFor(urlPathMatching(urlToVerify))
+        case PUT    => putRequestedFor(urlPathMatching(urlToVerify))
+        case DELETE => deleteRequestedFor(urlPathMatching(urlToVerify))
+        case _      => throw new RuntimeException("Invalid method type")
       }
     )
 }

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -40,15 +40,23 @@ trait WireMockSupportProvider extends WireMockSupport {
 
   def config: Configuration
 
-  protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET, count: Int = 1): Unit =
+  protected def verifyExactlyOneEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET): Unit =
     wireMockServer.verify(
-      count,
-      methodType match {
-        case GET    => getRequestedFor(urlPathMatching(urlToVerify))
-        case POST   => postRequestedFor(urlPathMatching(urlToVerify))
-        case PUT    => putRequestedFor(urlPathMatching(urlToVerify))
-        case DELETE => deleteRequestedFor(urlPathMatching(urlToVerify))
-        case _      => throw new RuntimeException("Invalid method type")
-      }
+      1,
+      buildRequestPatternForRequestedUrl(urlToVerify, methodType)
     )
+
+  protected def verifyEndPointUrlHit(urlToVerify: String, methodType: RequestMethod = GET): Unit =
+    wireMockServer.verify(
+      buildRequestPatternForRequestedUrl(urlToVerify, methodType)
+    )
+
+  private def buildRequestPatternForRequestedUrl(urlToVerify: String, methodType: RequestMethod) =
+    methodType match {
+      case GET    => getRequestedFor(urlPathMatching(urlToVerify))
+      case POST   => postRequestedFor(urlPathMatching(urlToVerify))
+      case PUT    => putRequestedFor(urlPathMatching(urlToVerify))
+      case DELETE => deleteRequestedFor(urlPathMatching(urlToVerify))
+      case _      => throw new RuntimeException("Invalid method type")
+    }
 }

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+import play.api.Configuration
+import uk.gov.hmrc.http.test.WireMockSupport
+import org.scalatest.Suite
+import com.github.tomakehurst.wiremock.client.WireMock.{getRequestedFor, urlPathMatching}
+
+trait WireMockSupportProvider extends WireMockSupport {
+  me: Suite =>
+
+  val X_FORWARDED_HOST = "X-Forwarded-Host"
+  val CONTENT_TYPE     = "Content-Type"
+  val ACCEPT           = "Accept"
+  val AUTHORIZATION    = "Authorization"
+
+  def config: Configuration
+
+  protected def verifyEndPointUrlHit(urlToVerify: String): Unit = wireMockServer.verify(
+    getRequestedFor(
+      urlPathMatching(urlToVerify)
+    )
+  )
+}

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -19,7 +19,7 @@ import play.api.Configuration
 import uk.gov.hmrc.http.test.WireMockSupport
 import org.scalatest.Suite
 import com.github.tomakehurst.wiremock.client.WireMock.{
-  deleteRequestedFor, getRequestedFor, postRequestedFor, put, putRequestedFor, urlPathMatching
+  deleteRequestedFor, getRequestedFor, postRequestedFor, putRequestedFor, urlPathMatching
 }
 import com.github.tomakehurst.wiremock.http.RequestMethod
 import com.github.tomakehurst.wiremock.http.RequestMethod.{DELETE, GET, POST, PUT}


### PR DESCRIPTION
Description - Code changes to add WireMock support for all the connectors' spec

Below has been done as part of this PR

- [x] create common spec named WireMockSupportProvider to provide WireMock support
- [x] add checks for url, request body, headers and query parameters for relevant http methods
- [x] entire request has been matched wherever possible , when it is not possible (due to dynamic runtime value for current date or UUID or random acknowledgement ref no), json path of the request has been matched
- [x] tests have been updated
- [x] minor refactoring
- [x] scala formatter applied in the relevant files