### PR TITLE
[MMCA-5207] - Updates to customs-financials-api for EORI regex/checks

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -179,5 +179,5 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
   lazy val mongoHistDocSearchTtl: Long =
     configuration.get[Long]("mongodb.historic-document-request-search.timeToLiveInSeconds")
 
-  lazy val euEoriEnabled: Boolean = configuration.get[Boolean]("features.eu-eori-enabled")
+  lazy val isEuEoriEnabled: Boolean = configuration.get[Boolean]("features.eu-eori-enabled")
 }

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -178,4 +178,6 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, configuration: Config
 
   lazy val mongoHistDocSearchTtl: Long =
     configuration.get[Long]("mongodb.historic-document-request-search.timeToLiveInSeconds")
+
+  lazy val euEoriEnabled: Boolean = configuration.get[Boolean]("features.eu-eori-enabled")
 }

--- a/app/connectors/Acc40Connector.scala
+++ b/app/connectors/Acc40Connector.scala
@@ -26,7 +26,7 @@ import services.{AuditingService, DateTimeService}
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
-import utils.Utils.{gbEoriPrefix, xIEoriPrefix}
+import utils.Utils.{euEoriRegex, gbEoriPrefix, xIEoriPrefix}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -88,6 +88,7 @@ class Acc40Connector @Inject() (
   def searchType(searchID: EORI): String =
     searchID.value match {
       case searchEori if searchEori.startsWith(gbEoriPrefix) || searchEori.startsWith(xIEoriPrefix) => "0"
+      case searchEori if appConfig.euEoriEnabled && euEoriRegex.matches(searchEori)                 => "0"
       case _                                                                                        => "1"
     }
 }

--- a/app/connectors/Acc40Connector.scala
+++ b/app/connectors/Acc40Connector.scala
@@ -88,7 +88,7 @@ class Acc40Connector @Inject() (
   def searchType(searchID: EORI): String =
     searchID.value match {
       case searchEori if searchEori.startsWith(gbEoriPrefix) || searchEori.startsWith(xIEoriPrefix) => "0"
-      case searchEori if appConfig.euEoriEnabled && euEoriRegex.matches(searchEori)                 => "0"
+      case searchEori if appConfig.isEuEoriEnabled && euEoriRegex.matches(searchEori)               => "0"
       case _                                                                                        => "1"
     }
 }

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -40,6 +40,7 @@ object Utils {
   val comma                = ","
   val gbEoriPrefix         = "GB"
   val xIEoriPrefix         = "XI"
+  val euEoriRegex          = "^[A-Z]{2}[0-9A-Z]{1,15}$".r
 
   val UTC_TIME_ZONE = "UTC"
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -277,4 +277,5 @@ mongodb {
 
 features {
     onlyOpenItems = true
+    eu-eori-enabled = false
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.10.0"
+  val bootstrapVersion = "9.11.0"
   val mongoVersion     = "2.5.0"
 
   val compile: Seq[ModuleID] = Seq(

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -21,6 +21,12 @@ import utils.SpecBase
 
 class AppConfigSpec extends SpecBase {
 
+  "Appconfig" should {
+    "load configuration values correctly" in new Setup {
+      appConfig.euEoriEnabled mustBe false
+    }
+  }
+
   "mongoHistDocSearchCollectionName" should {
     "return correct name for the collection" in new Setup {
       appConfig.mongoHistDocSearchCollectionName mustBe "historic-document-request-search"

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -21,9 +21,9 @@ import utils.SpecBase
 
 class AppConfigSpec extends SpecBase {
 
-  "Appconfig" should {
-    "load configuration values correctly" in new Setup {
-      appConfig.euEoriEnabled mustBe false
+  "euEoriEnabled" should {
+    "return the correct value" in new Setup {
+      appConfig.isEuEoriEnabled mustBe false
     }
   }
 

--- a/test/connectors/Acc40ConnectorSpec.scala
+++ b/test/connectors/Acc40ConnectorSpec.scala
@@ -30,11 +30,6 @@ import play.api.libs.json.Json
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, matchingJsonPath, ok, post, urlPathMatching}
 import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
-import config.AppConfig
-import org.mockito.Mockito.when
-import play.api.inject.guice.GuiceApplicationBuilder
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.inject.bind
 
 class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
 
@@ -208,8 +203,8 @@ class Acc40ConnectorSpec extends SpecBase with WireMockSupportProvider {
           override val connector: Acc40Connector = app.injector.instanceOf[Acc40Connector]
 
           val searchTypeValue: String = connector.searchType(EORI("FR123456789012"))
-          searchTypeValue mustBe "0"
 
+          searchTypeValue mustBe "0"
         }
       }
 

--- a/test/domain/acc40/RequestSpec.scala
+++ b/test/domain/acc40/RequestSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain.acc40
+
+import models.EORI
+import org.scalatest.matchers.should.Matchers.shouldBe
+import play.api.libs.json.{JsValue, Json}
+import utils.SpecBase
+
+class RequestSpec extends SpecBase {
+  "SearchAuthoritiesRequest JSON writes" should {
+    "should correctly serialize to JSON" in {
+      val requestCommon = RequestCommon(
+        receiptDate = "2024-03-11T12:00:00Z",
+        originatingSystem = "TestSystem",
+        acknowledgementReference = "ABC123456789",
+        regime = "CDS"
+      )
+
+      val requestDetail = RequestDetail(
+        requestingEORI = EORI("GB744638982004"),
+        searchType = "0",
+        searchID = EORI("GB744638982004")
+      )
+
+      val request                  = domain.acc40.Request(requestCommon, requestDetail)
+      val searchAuthoritiesRequest = domain.acc40.SearchAuthoritiesRequest(request)
+
+      val json: JsValue = Json.toJson(searchAuthoritiesRequest)
+
+      val expectedJson = Json.parse(
+        """
+             {
+               "searchAuthoritiesRequest": {
+                 "requestCommon": {
+                   "receiptDate": "2024-03-11T12:00:00Z",
+                   "originatingSystem": "TestSystem",
+                   "acknowledgementReference": "ABC123456789",
+                   "regime": "CDS"
+                 },
+                 "requestDetail": {
+                   "requestingEORI": "GB744638982004",
+                   "searchType": "0",
+                   "searchID": "GB744638982004"
+                 }
+               }
+             }
+             """
+      )
+
+      json shouldBe expectedJson
+
+      (json \ "searchAuthoritiesRequest" \ "requestCommon" \ "receiptDate").as[String]       shouldBe "2024-03-11T12:00:00Z"
+      (json \ "searchAuthoritiesRequest" \ "requestCommon" \ "originatingSystem").as[String] shouldBe "TestSystem"
+      (json \ "searchAuthoritiesRequest" \ "requestCommon" \ "acknowledgementReference")
+        .as[String]                                                                          shouldBe "ABC123456789"
+      (json \ "searchAuthoritiesRequest" \ "requestCommon" \ "regime").as[String]            shouldBe "CDS"
+
+      (json \ "searchAuthoritiesRequest" \ "requestDetail" \ "requestingEORI").as[String] shouldBe "GB744638982004"
+      (json \ "searchAuthoritiesRequest" \ "requestDetail" \ "searchType").as[String]     shouldBe "0"
+      (json \ "searchAuthoritiesRequest" \ "requestDetail" \ "searchID").as[String]       shouldBe "GB744638982004"
+    }
+  }
+}

--- a/test/domain/acc40/SearchAuthoritiesRequestSpec.scala
+++ b/test/domain/acc40/SearchAuthoritiesRequestSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.matchers.should.Matchers.shouldBe
 import play.api.libs.json.{JsValue, Json}
 import utils.SpecBase
 
-class RequestSpec extends SpecBase {
+class SearchAuthoritiesRequestSpec extends SpecBase {
   "SearchAuthoritiesRequest JSON writes" should {
     "should correctly serialize to JSON" in {
       val requestCommon = RequestCommon(


### PR DESCRIPTION
- [x] Implement a feature flag for these changes called "features.eu-eori-enabled". Set this to true in app-config-development and false in the other environments, including local.
- [x] Update `searchType` method in `Acc40Connector` such that it will allow for European EORIs. That is, it should accept EORIs with the following pattern ^[A-Z] {2} [0-9A-Z] {1,15}$
- [x] Add tests for the feature flag and the updated EORI pattern.
- [x] Add missing Acc40 RequestSpec
- [x] Test Endpoint 