### PR TITLE
MMCA-5231 - Date format fix in Java21 of customs-financials-api

### DIFF
--- a/app/models/EmailTemplate.scala
+++ b/app/models/EmailTemplate.scala
@@ -22,9 +22,8 @@ import utils.Utils.{DD1720_STT_TYPE, DD1920_STT_TYPE, EXCISE_STT_TYPE, abbreviat
 
 import java.time.LocalDate
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
-import java.time.temporal.{ChronoField, ChronoUnit}
+import java.time.temporal.ChronoField
 import java.util.Locale
-import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 sealed trait EmailTemplate {

--- a/app/models/EmailTemplate.scala
+++ b/app/models/EmailTemplate.scala
@@ -18,7 +18,7 @@ package models
 
 import domain.Notification
 import models.requests.EmailRequest
-import utils.Utils.{DD1720_STT_TYPE, DD1920_STT_TYPE, EXCISE_STT_TYPE, abbreviatedMonth, emptyString}
+import utils.Utils.{DD1720_STT_TYPE, DD1920_STT_TYPE, EXCISE_STT_TYPE, abbreviatedMonth, emptyString, singleSpace}
 
 import java.time.LocalDate
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
@@ -45,9 +45,9 @@ object EmailTemplate {
   private val DD1720_STT_DUE_DATE                  = 15
 
   val emailDateFormatter: DateTimeFormatter = DateTimeFormatterBuilder()
-    .appendPattern("dd ")
+    .appendPattern(s"dd$singleSpace")
     .appendText(ChronoField.MONTH_OF_YEAR, abbreviatedMonth)
-    .appendPattern(" yyyy")
+    .appendPattern(s"${singleSpace}yyyy")
     .toFormatter(Locale.ENGLISH)
 
   def fromNotification(

--- a/app/models/EmailTemplate.scala
+++ b/app/models/EmailTemplate.scala
@@ -18,10 +18,13 @@ package models
 
 import domain.Notification
 import models.requests.EmailRequest
-import utils.Utils.{DD1720_STT_TYPE, DD1920_STT_TYPE, EXCISE_STT_TYPE, emptyString}
+import utils.Utils.{DD1720_STT_TYPE, DD1920_STT_TYPE, EXCISE_STT_TYPE, abbreviatedMonth, emptyString}
 
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.{ChronoField, ChronoUnit}
+import java.util.Locale
+import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
 sealed trait EmailTemplate {
@@ -40,7 +43,12 @@ object EmailTemplate {
   private val CUSTOMS_DUTY_AND_IMPORT_VAT_DUE_DATE = 16
   private val DD1920_STT_DUE_DATE                  = 25
   private val DD1720_STT_DUE_DATE                  = 15
-  private val emailDateFormatter                   = DateTimeFormatter.ofPattern("dd MMM yyyy")
+
+  val emailDateFormatter: DateTimeFormatter = DateTimeFormatterBuilder()
+    .appendPattern("dd ")
+    .appendText(ChronoField.MONTH_OF_YEAR, abbreviatedMonth)
+    .appendPattern(" yyyy")
+    .toFormatter(Locale.ENGLISH)
 
   def fromNotification(
     emailAddress: EmailAddress,

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -28,9 +28,16 @@ import java.util.Locale
 import scala.jdk.CollectionConverters.*
 
 object Utils {
-  val emptyString            = ""
-  val threeColons            = ":::"
-  val rfc7231DateTimePattern = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+  val emptyString    = ""
+  val threeColons    = ":::"
+  val englishLangKey = "en"
+  val welshLangKey   = "cy"
+  val singleSpace    = " "
+  val hyphen         = "-"
+  val comma          = ","
+  val gbEoriPrefix   = "GB"
+  val xIEoriPrefix   = "XI"
+  val euEoriRegex    = "^[A-Z]{2}[0-9A-Z]{1,15}$".r
 
   val abbreviatedMonth = Map(
     1L  -> "Jan",
@@ -48,22 +55,14 @@ object Utils {
   ).map { case (k, v) => (k: java.lang.Long) -> v }.asJava
 
   val httpDateFormatter: DateTimeFormatter = new DateTimeFormatterBuilder()
-    .appendPattern("EEE, dd ")
+    .appendPattern(s"EEE, dd$singleSpace")
     .appendText(ChronoField.MONTH_OF_YEAR, abbreviatedMonth)
-    .appendPattern(" yyyy HH:mm:ss 'GMT'")
+    .appendPattern(s"${singleSpace}yyyy HH:mm:ss 'GMT'")
     .toFormatter(Locale.ENGLISH)
 
   val iso8601DateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME
-
-  val iso8601DateTimeRegEx = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
-  val englishLangKey       = "en"
-  val welshLangKey         = "cy"
-  val singleSpace          = " "
-  val hyphen               = "-"
-  val comma                = ","
-  val gbEoriPrefix         = "GB"
-  val xIEoriPrefix         = "XI"
-  val euEoriRegex          = "^[A-Z]{2}[0-9A-Z]{1,15}$".r
+  val rfc7231DateTimePattern                  = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+  val iso8601DateTimeRegEx                    = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"
 
   val UTC_TIME_ZONE = "UTC"
 

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -22,14 +22,37 @@ import play.api.http.{ContentTypeOf, ContentTypes, Writeable}
 import play.api.libs.json.Writes
 
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.{ChronoField, ChronoUnit}
+import java.util.Locale
+import scala.jdk.CollectionConverters.*
 
 object Utils {
-  val emptyString                             = ""
-  val threeColons                             = ":::"
-  val rfc7231DateTimePattern                  = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
-  val httpDateFormatter: DateTimeFormatter    = DateTimeFormatter.ofPattern(rfc7231DateTimePattern)
+  val emptyString            = ""
+  val threeColons            = ":::"
+  val rfc7231DateTimePattern = "EEE, dd MMM yyyy HH:mm:ss 'GMT'"
+
+  val abbreviatedMonth = Map(
+    1L  -> "Jan",
+    2L  -> "Feb",
+    3L  -> "Mar",
+    4L  -> "Apr",
+    5L  -> "May",
+    6L  -> "Jun",
+    7L  -> "Jul",
+    8L  -> "Aug",
+    9L  -> "Sep",
+    10L -> "Oct",
+    11L -> "Nov",
+    12L -> "Dec"
+  ).map { case (k, v) => (k: java.lang.Long) -> v }.asJava
+
+  val httpDateFormatter: DateTimeFormatter = new DateTimeFormatterBuilder()
+    .appendPattern("EEE, dd ")
+    .appendText(ChronoField.MONTH_OF_YEAR, abbreviatedMonth)
+    .appendPattern(" yyyy HH:mm:ss 'GMT'")
+    .toFormatter(Locale.ENGLISH)
+
   val iso8601DateFormatter: DateTimeFormatter = DateTimeFormatter.ISO_DATE_TIME
 
   val iso8601DateTimeRegEx = "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z"

--- a/app/utils/Utils.scala
+++ b/app/utils/Utils.scala
@@ -25,7 +25,7 @@ import java.time.LocalDateTime
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.temporal.{ChronoField, ChronoUnit}
 import java.util.Locale
-import scala.jdk.CollectionConverters.*
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 object Utils {
   val emptyString    = ""

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ import sbt.*
 object AppDependencies {
 
   val bootstrapVersion = "9.11.0"
-  val mongoVersion     = "2.5.0"
+  val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(
     ws,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.10

--- a/test/controllers/metadata/MetadataControllerSpec.scala
+++ b/test/controllers/metadata/MetadataControllerSpec.scala
@@ -25,7 +25,6 @@ import models.requests.EmailRequest
 import org.mockito.ArgumentMatchers.{any, eq => is}
 import org.mockito.Mockito.{verify, when}
 import org.mockito.{ArgumentMatchers, Mockito}
-import play.api.http.Status.BAD_REQUEST
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsArray, JsValue, Json}
 import play.api.mvc.AnyContentAsJson

--- a/test/domain/EmailGetSpecificClaimRequestSpec.scala
+++ b/test/domain/EmailGetSpecificClaimRequestSpec.scala
@@ -482,5 +482,4 @@ class EmailGetSpecificClaimRequestSpec extends SpecBase {
       }
     }
   }
-
 }

--- a/test/models/EmailTemplateSpec.scala
+++ b/test/models/EmailTemplateSpec.scala
@@ -40,6 +40,7 @@ class EmailTemplateSpec extends SpecBase {
         LocalDate.of(YEAR_2023, MONTH_9, DAY_1)  -> "01 Sep 2023",
         LocalDate.of(YEAR_2020, MONTH_2, DAY_16) -> "16 Feb 2020"
       )
+
       testCases.foreach { case (date, expected) =>
         EmailTemplate.emailDateFormatter.format(date) mustBe expected
       }

--- a/test/models/EmailTemplateSpec.scala
+++ b/test/models/EmailTemplateSpec.scala
@@ -21,7 +21,7 @@ import models.EmailTemplate.emailDateFormatter
 import utils.SpecBase
 import utils.TestData.{DAY_1, DAY_11, DAY_15, DAY_16, MONTH_2, MONTH_7, MONTH_9, YEAR_2019, YEAR_2020, YEAR_2023}
 
-import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+import java.time.LocalDate
 import scala.collection.immutable.{HashMap, Map}
 
 class EmailTemplateSpec extends SpecBase {

--- a/test/models/EmailTemplateSpec.scala
+++ b/test/models/EmailTemplateSpec.scala
@@ -17,13 +17,34 @@
 package models
 
 import domain.Notification
+import models.EmailTemplate.emailDateFormatter
 import utils.SpecBase
-import utils.TestData.{MONTH_2, MONTH_9, YEAR_2019, YEAR_2020}
+import utils.TestData.{DAY_1, DAY_11, DAY_15, DAY_16, MONTH_2, MONTH_7, MONTH_9, YEAR_2019, YEAR_2020, YEAR_2023}
 
-import java.time.LocalDate
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import scala.collection.immutable.{HashMap, Map}
 
 class EmailTemplateSpec extends SpecBase {
+
+  "emailDateFormatter" should {
+    "format date correctly" in {
+      val testDateTime  = LocalDate.of(YEAR_2023, MONTH_9, DAY_15)
+      val formattedDate = emailDateFormatter.format(testDateTime)
+
+      formattedDate mustBe "15 Sep 2023"
+    }
+
+    "use correct month abbreviations" in {
+      val testCases = Seq(
+        LocalDate.of(YEAR_2019, MONTH_7, DAY_11) -> "11 Jul 2019",
+        LocalDate.of(YEAR_2023, MONTH_9, DAY_1)  -> "01 Sep 2023",
+        LocalDate.of(YEAR_2020, MONTH_2, DAY_16) -> "16 Feb 2020"
+      )
+      testCases.foreach { case (date, expected) =>
+        EmailTemplate.emailDateFormatter.format(date) mustBe expected
+      }
+    }
+  }
 
   "fromNotification" should {
 

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -84,6 +84,12 @@ object TestData {
   val NUMBER_9  = 9
   val NUMBER_10 = 10
 
+  val OneL      = 1L
+  val FiveL     = 5L
+  val NineL     = 9L
+  val ThirteenL = 13L
+  val TwentyL   = 20L
+
   val COUNTRY_CODE_GB = "GB"
 
   val REGIME = "cds"

--- a/test/utils/UtilsSpec.scala
+++ b/test/utils/UtilsSpec.scala
@@ -21,7 +21,7 @@ import utils.TestData.*
 import utils.Utils.*
 
 import java.time.format.DateTimeFormatter
-import scala.jdk.CollectionConverters.*
+import scala.jdk.CollectionConverters.MapHasAsScala
 import java.time.{LocalDate, LocalDateTime, ZoneOffset, ZonedDateTime}
 import java.util.Locale
 


### PR DESCRIPTION
- [x] Write manual date formatter - 3 letters for all months
- [x] Update emailDateFormatter & httpDateFormatter
- [x] Write new tests
- [x] Check endpoints and email outputs.
- [x] All Tests pass in Java 11 & Java 21   