### PR TITLE
[MMCA-5411] - Map 404 status code correctly for ACC44 and ACC45 calls

### DIFF
--- a/app/connectors/Acc44Connector.scala
+++ b/app/connectors/Acc44Connector.scala
@@ -94,9 +94,7 @@ class Acc44Connector @Inject() (
 
   private def postValidRequest(
     cashAccTransSearchRequestContainer: CashAccountTransactionSearchRequestContainer
-  ): Future[Either[ErrorDetail, CashAccountTransactionSearchResponseContainer]] = {
-    val errorStatusList = List(BAD_REQUEST, INTERNAL_SERVER_ERROR, NOT_FOUND)
-
+  ): Future[Either[ErrorDetail, CashAccountTransactionSearchResponseContainer]] =
     metricsReporterService.withResponseTimeLogging("hods.post.cash-account-transaction-search") {
       httpClient
         .post(url"${appConfig.acc44CashTransactionSearchEndpoint}")(HeaderCarrier())
@@ -114,7 +112,7 @@ class Acc44Connector @Inject() (
                 Right(retrieveCashAccountTransactionSsearchResponse(res))
               }
 
-            case resStatus if errorStatusList.contains(resStatus) =>
+            case resStatus =>
               if (isResponseContainsErrorDetails(res)) {
                 Left(retrieveErrorDetailsResponse(res))
               } else {
@@ -122,20 +120,6 @@ class Acc44Connector @Inject() (
                   populateErrorDetails(
                     res.status.toString,
                     if (resStatus == NOT_FOUND) BACK_END_FAILURE else SERVER_CONNECTION_ERROR,
-                    backEnd,
-                    SourceFaultDetail(Seq(BACK_END_FAILURE))
-                  )
-                )
-              }
-
-            case _ =>
-              if (isResponseContainsErrorDetails(res)) {
-                Left(retrieveErrorDetailsResponse(res))
-              } else {
-                Left(
-                  populateErrorDetails(
-                    res.status.toString,
-                    SERVER_CONNECTION_ERROR,
                     backEnd,
                     SourceFaultDetail(Seq(BACK_END_FAILURE))
                   )
@@ -151,7 +135,6 @@ class Acc44Connector @Inject() (
           )
         }
     }
-  }
 
   private def validateAndProcessIncomingSuccessResponse(
     res: HttpResponse

--- a/app/controllers/CashTransactionsController.scala
+++ b/app/controllers/CashTransactionsController.scala
@@ -78,6 +78,7 @@ class CashTransactionsController @Inject() (service: CashTransactionsService, cc
   private def handleCashAccSttResFailures(errorDetail: ErrorDetail): Result =
     errorDetail.errorCode match {
       case "400" => BadRequest(Json.toJson(errorDetail))
+      case "404" => NotFound(Json.toJson(errorDetail))
       case "500" => InternalServerError(Json.toJson(errorDetail))
       case _     => ServiceUnavailable(Json.toJson(errorDetail))
     }

--- a/app/controllers/CashTransactionsController.scala
+++ b/app/controllers/CashTransactionsController.scala
@@ -93,6 +93,7 @@ class CashTransactionsController @Inject() (service: CashTransactionsService, cc
 
     errorDetail.errorCode match {
       case "400"                                                   => BadRequest(errorDetail)
+      case "404"                                                   => NotFound(errorDetail)
       case "500"                                                   => InternalServerError(errorDetail)
       case etmpErrorCode if etmpErrorCodes.contains(etmpErrorCode) => Created(errorDetail)
       case _                                                       => ServiceUnavailable(errorDetail)

--- a/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
+++ b/app/models/responses/StatementSearchFailureNotificationErrorResponse.scala
@@ -149,6 +149,7 @@ object ErrorSource {
 
 object ErrorCode {
   val code400 = "400"
+  val code404 = "404"
   val code500 = "500"
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import AppDependencies.bootstrapVersion
 
 val appName = "customs-financials-api"
 
-val scala3_3_5      = "3.3.5"
+val scala3_3_6      = "3.3.6"
 val silencerVersion = "1.7.16"
 
 val testDirectory            = "test"
@@ -12,7 +12,7 @@ val scalaStyleConfigFile     = "scalastyle-config.xml"
 val testScalaStyleConfigFile = "test-scalastyle-config.xml"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := scala3_3_5
+ThisBuild / scalaVersion := scala3_3_6
 
 lazy val it = project
   .enablePlugins(PlayScala)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "9.11.0"
+  val bootstrapVersion = "9.14.0"
   val mongoVersion     = "2.6.0"
 
   val compile: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 )
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.6")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.7")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.9")
 addSbtPlugin(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 )
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.7")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.8")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.0.9")
 addSbtPlugin(

--- a/test/controllers/CashTransactionsControllerSpec.scala
+++ b/test/controllers/CashTransactionsControllerSpec.scala
@@ -22,13 +22,13 @@ import models.requests.SearchType.P
 import models.requests.{
   CashAccountPaymentDetails, CashAccountStatementRequestDetail, CashAccountTransactionSearchRequestDetails
 }
-import models.responses.ErrorCode.{code400, code500}
+import models.responses.ErrorCode.{code400, code404, code500}
 import models.responses.EtmpErrorCode.code001
 import models.responses.PaymentType.Payment
 import models.responses.{Acc45ResponseCommon, ErrorDetail, *}
 import models.{EORI, ExceededThresholdErrorException, NoAssociatedDataException}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.{any, eq => is}
+import org.mockito.ArgumentMatchers.{any, eq as is}
 import org.mockito.Mockito.when
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
@@ -234,6 +234,18 @@ class CashTransactionsControllerSpec extends SpecBase {
       }
     }
 
+    "return error response for 404 error code" in new Setup {
+      when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
+        .thenReturn(Future.successful(Left(errorDetails.copy(errorCode = code404))))
+
+      running(app) {
+        val result = route(app, retrieveCashAccountTransactions).value
+
+        status(result) mustBe NOT_FOUND
+        contentAsJson(result) mustBe Json.toJson(errorDetails.copy(errorCode = code404))
+      }
+    }
+
     "return error response for 500 error code" in new Setup {
       when(mockCashTransactionsService.retrieveCashAccountTransactions(any)(any))
         .thenReturn(
@@ -288,6 +300,7 @@ class CashTransactionsControllerSpec extends SpecBase {
       }
     }
   }
+
   "submitCashAccStatementRequest" should {
 
     "return ResponseCommon for success scenario" in new Setup {

--- a/test/controllers/CashTransactionsControllerSpec.scala
+++ b/test/controllers/CashTransactionsControllerSpec.scala
@@ -28,7 +28,7 @@ import models.responses.PaymentType.Payment
 import models.responses.{Acc45ResponseCommon, ErrorDetail, *}
 import models.{EORI, ExceededThresholdErrorException, NoAssociatedDataException}
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.{any, eq as is}
+import org.mockito.ArgumentMatchers.{any, eq => is}
 import org.mockito.Mockito.when
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsValue, Json}
@@ -440,6 +440,36 @@ class CashTransactionsControllerSpec extends SpecBase {
         val result = route(app, submitCashAccStatementRequest).value
 
         status(result) mustBe SERVICE_UNAVAILABLE
+        contentAsJson(result) mustBe Json.toJson(response)
+      }
+    }
+
+    "return ErrorDetails for NotFound scenarios as business error" in new Setup {
+
+      val acc45ResStr: String =
+        """
+          |{
+          |  "timestamp": "2024-01-21T11:30:47Z",
+          |  "correlationId": "f058ebd6-02f7-4d3f-942e-904344e8cde5",
+          |  "errorCode": "404",
+          |  "errorMessage": "Failure in backend System",
+          |  "source": "Backend",
+          |  "sourceFaultDetail": {
+          |    "detail": [
+          |      "Failure in backend System"
+          |    ]
+          |  }
+          |}""".stripMargin
+
+      val response: ErrorDetail = Json.fromJson[ErrorDetail](Json.parse(acc45ResStr)).get
+
+      when(mockCashTransactionsService.submitCashAccountStatementRequest(ArgumentMatchers.eq(cashAccSttRequest))(any))
+        .thenReturn(Future.successful(Left(response)))
+
+      running(app) {
+        val result = route(app, submitCashAccStatementRequest).value
+
+        status(result) mustBe NOT_FOUND
         contentAsJson(result) mustBe Json.toJson(response)
       }
     }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -115,4 +115,6 @@ object TestData {
   val IMPORTERS_EORI_NUMBER         = "GB1234567"
 
   val ORIGINATING_SYSTEM = "MDTP"
+
+  val CORRELATION_ID = "MDTP_ID"
 }


### PR DESCRIPTION
Description - Handle 404 response for ACC44 and ACC45 calls

Below has been done as part of this PR

- [x] add case statements to handle 404
- [x] add tests
- [x] minor refactoring